### PR TITLE
Refactor analytics tests into separate files

### DIFF
--- a/analytics-data-center/internal/lib/duplicate/duplicate_test.go
+++ b/analytics-data-center/internal/lib/duplicate/duplicate_test.go
@@ -1,0 +1,36 @@
+package duplicate
+
+import (
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoveDuplicate(t *testing.T) {
+	input := []int{1, 2, 2, 3, 1}
+	clean, dup := RemoveDuplicate(input)
+
+	require.Equal(t, []int{1, 2, 3}, clean)
+	require.Equal(t, []int{2, 1}, dup)
+}
+
+func TestRemoveDuplicateColumns(t *testing.T) {
+	cols := []models.Column{
+		{Name: "id"},
+		{Name: "name"},
+		{Name: "id"},
+		{Name: "age", Alias: "age_alias"},
+		{Name: "age2", Alias: "age_alias"},
+		{Name: "weight"},
+	}
+
+	clean, dups := RemoveDuplicateColumns(cols)
+
+	require.Len(t, clean, 4)
+	require.Equal(t, []string{"id", "age_alias"}, dups)
+	require.Equal(t, "id", clean[0].Name)
+	require.Equal(t, "name", clean[1].Name)
+	require.Equal(t, "age", clean[2].Name)
+	require.Equal(t, "weight", clean[3].Name)
+}

--- a/analytics-data-center/internal/services/analytics/analytics_count_data_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_count_data_test.go
@@ -1,0 +1,36 @@
+package serviceanalytics
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+	"analyticDataCenter/analytics-data-center/internal/storage"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCountInsertData(t *testing.T) {
+	oltp := &mockOLTP{countResult: 5}
+	factory := &mockFactory{store: map[string]storage.OLTPDB{"db1": oltp}}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), OLTPFactory: factory}
+
+	view := models.View{Sources: []models.Source{{Name: "db1", Schemas: []models.Schema{{Tables: []models.Table{{Name: "users"}}}}}}}
+	res, err := svc.getCountInsertData(context.Background(), view, []string{"tmp"})
+
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, int64(5), res[0].Count)
+	require.Equal(t, "tmp", res[0].TempTableName)
+}
+
+func TestGetCountInsertDataStorageError(t *testing.T) {
+	factory := &mockFactory{err: fmt.Errorf("no storage")}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), OLTPFactory: factory}
+	view := models.View{Sources: []models.Source{{Name: "db1", Schemas: []models.Schema{{Tables: []models.Table{{Name: "users"}}}}}}}
+
+	_, err := svc.getCountInsertData(context.Background(), view, []string{"tmp"})
+
+	require.Error(t, err)
+}

--- a/analytics-data-center/internal/services/analytics/analytics_indices_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_indices_test.go
@@ -1,0 +1,25 @@
+package serviceanalytics
+
+import (
+	"context"
+	"testing"
+
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+	"analyticDataCenter/analytics-data-center/internal/storage"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTransferIndices(t *testing.T) {
+	indexSQL := "CREATE INDEX idx ON public.t1(id)"
+	oltp := &mockOLTP{indexResult: models.Indexes{Indexes: []models.Index{{IndexName: "idx", IndexDef: indexSQL}}}}
+	factory := &mockFactory{store: map[string]storage.OLTPDB{"db1": oltp}}
+	dwh := &mockDWH{}
+	view := &models.View{Sources: []models.Source{{Name: "db1", Schemas: []models.Schema{{Name: "public", Tables: []models.Table{{Name: "t1"}}}}}}}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), OLTPFactory: factory, DWHProvider: dwh}
+
+	err := svc.transferIndixesAndConstraint(context.Background(), view)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, dwh.indexCalls)
+}

--- a/analytics-data-center/internal/services/analytics/analytics_prepare_insert_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_prepare_insert_test.go
@@ -1,0 +1,43 @@
+package serviceanalytics
+
+import (
+	"context"
+	"testing"
+
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+	"analyticDataCenter/analytics-data-center/internal/storage"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareAndInsertData(t *testing.T) {
+	oltp := &mockOLTP{selectResult: []map[string]interface{}{{"id": 1, "name": "A"}}}
+	factory := &mockFactory{store: map[string]storage.OLTPDB{"db1": oltp}}
+	dwh := &mockDWH{columns: map[string][]string{"tmp_users": {"id", "name"}}}
+	view := &models.View{
+		Name: "v",
+		Sources: []models.Source{{
+			Name: "db1",
+			Schemas: []models.Schema{{
+				Name: "public",
+				Tables: []models.Table{{
+					Name: "users",
+					Columns: []models.Column{
+						{Name: "id", IsPrimaryKey: true},
+						{Name: "name"},
+					},
+				}},
+			}},
+		}},
+	}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), OLTPFactory: factory, DWHProvider: dwh}
+	data := []models.CountInsertData{{TableName: "users", Count: 1, DataBaseName: "db1", TempTableName: "tmp_users"}}
+
+	ok, err := svc.prepareAndInsertData(context.Background(), &data, view)
+
+	require.True(t, ok)
+	require.NoError(t, err)
+	require.NotEmpty(t, dwh.insertCalls)
+	require.Equal(t, 1, dwh.mergeCalls)
+	require.Equal(t, []string{"tmp_users"}, dwh.deleteCalls)
+}

--- a/analytics-data-center/internal/services/analytics/analytics_temp_tables_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_temp_tables_test.go
@@ -1,0 +1,55 @@
+package serviceanalytics
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateTempTablesSuccess(t *testing.T) {
+	dwh := &mockDWH{}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), DWHProvider: dwh}
+	queries := models.Queries{Queries: []models.Query{{TableName: "t1"}, {TableName: "t2"}}}
+
+	err := svc.createTempTables(context.Background(), queries)
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"t1", "t2"}, dwh.createCalls)
+	require.Empty(t, dwh.deleteCalls)
+}
+
+func TestCreateTempTablesErrorCleanup(t *testing.T) {
+	dwh := &mockDWH{createErrors: map[string]error{"t2": fmt.Errorf("fail")}}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), DWHProvider: dwh}
+	queries := models.Queries{Queries: []models.Query{{TableName: "t1"}, {TableName: "t2"}}}
+
+	err := svc.createTempTables(context.Background(), queries)
+
+	require.Error(t, err)
+	require.Equal(t, []string{"t1", "t2"}, dwh.createCalls)
+	require.Equal(t, []string{"t1", "t2"}, dwh.deleteCalls)
+}
+
+func TestDeleteTempTables(t *testing.T) {
+	dwh := &mockDWH{}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), DWHProvider: dwh}
+
+	err := svc.DeleteTempTables(context.Background(), []string{"t1", "t2"})
+
+	require.NoError(t, err)
+	require.Equal(t, []string{"t1", "t2"}, dwh.deleteCalls)
+}
+
+func TestDeleteTempTablesError(t *testing.T) {
+	dwh := &mockDWH{deleteErrors: map[string]error{"t2": fmt.Errorf("fail")}}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), DWHProvider: dwh}
+
+	err := svc.DeleteTempTables(context.Background(), []string{"t1", "t2"})
+
+	require.Error(t, err)
+	require.Equal(t, []string{"t1"}, dwh.deleteCalls[:1])
+}

--- a/analytics-data-center/internal/services/analytics/analytics_test_helpers.go
+++ b/analytics-data-center/internal/services/analytics/analytics_test_helpers.go
@@ -1,0 +1,120 @@
+package serviceanalytics
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+	"analyticDataCenter/analytics-data-center/internal/storage"
+)
+
+func getTestLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+type mockDWH struct {
+	createCalls  []string
+	deleteCalls  []string
+	columns      map[string][]string
+	createErrors map[string]error
+	deleteErrors map[string]error
+	insertCalls  []string
+	insertErr    error
+	mergeCalls   int
+	mergeErr     error
+	indexCalls   []string
+	indexErr     error
+}
+
+func (m *mockDWH) CreateTempTable(_ context.Context, _ string, name string) error {
+	m.createCalls = append(m.createCalls, name)
+	if err, ok := m.createErrors[name]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockDWH) DeleteTempTable(_ context.Context, name string) error {
+	m.deleteCalls = append(m.deleteCalls, name)
+	if err, ok := m.deleteErrors[name]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockDWH) CreateIndex(_ context.Context, query string) error {
+	m.indexCalls = append(m.indexCalls, query)
+	return m.indexErr
+}
+func (m *mockDWH) CreateConstraint(_ context.Context, _ string) error { return nil }
+func (m *mockDWH) InsertDataToDWH(_ context.Context, query string) error {
+	m.insertCalls = append(m.insertCalls, query)
+	return m.insertErr
+}
+func (m *mockDWH) GetColumnsTables(_ context.Context, _ string, table string) ([]string, error) {
+	if cols, ok := m.columns[table]; ok {
+		return cols, nil
+	}
+	return nil, fmt.Errorf("no columns")
+}
+func (m *mockDWH) MergeTempTables(_ context.Context, _ string) error {
+	m.mergeCalls++
+	return m.mergeErr
+}
+func (m *mockDWH) ReplicaIdentityFull(context.Context, string) error { return nil }
+func (m *mockDWH) InsertOrUpdateTransactional(context.Context, string, map[string]interface{}, []string) error {
+	return nil
+}
+
+// ---- OLTP mocks ----
+type mockOLTP struct {
+	countResult  int64
+	countErr     error
+	selectResult []map[string]interface{}
+	selectErr    error
+	indexResult  models.Indexes
+	indexErr     error
+}
+
+func (m *mockOLTP) GetCountInsertData(context.Context, string) (int64, error) {
+	if m.countErr != nil {
+		return 0, m.countErr
+	}
+	return m.countResult, nil
+}
+func (m *mockOLTP) SelectDataToInsert(context.Context, string) ([]map[string]interface{}, error) {
+	if m.selectErr != nil {
+		return nil, m.selectErr
+	}
+	return m.selectResult, nil
+}
+func (m *mockOLTP) GetIndexes(context.Context, string, string) (models.Indexes, error) {
+	if m.indexErr != nil {
+		return models.Indexes{}, m.indexErr
+	}
+	return m.indexResult, nil
+}
+func (m *mockOLTP) GetConstraint(context.Context, string, string) (models.Constraints, error) {
+	return models.Constraints{}, nil
+}
+
+// ---- factory ----
+type mockFactory struct {
+	store map[string]storage.OLTPDB
+	err   error
+}
+
+func (m *mockFactory) GetOLTPStorage(_ context.Context, name string) (storage.OLTPDB, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	st, ok := m.store[name]
+	if !ok {
+		return nil, fmt.Errorf("not found")
+	}
+	return st, nil
+}
+func (m *mockFactory) CloseAll() error                                  { return nil }
+func (m *mockFactory) GetOLTPStrings(context.Context) map[string]string { return nil }

--- a/analytics-data-center/internal/services/analytics/analytics_view_join_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_view_join_test.go
@@ -1,0 +1,19 @@
+package serviceanalytics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrepareViewJoin(t *testing.T) {
+	dwh := &mockDWH{columns: map[string][]string{"tmp1": {"id", "name"}}}
+	svc := &AnalyticsDataCenterService{log: getTestLogger(), DWHProvider: dwh}
+	res, err := svc.prepareViewJoin(context.Background(), []string{"tmp1"}, "public")
+
+	require.NoError(t, err)
+	require.Len(t, res.TempTables, 1)
+	require.Equal(t, "tmp1", res.TempTables[0].TempTableName)
+	require.Equal(t, "id", res.TempTables[0].TempColumns[0].ColumnName)
+}

--- a/analytics-data-center/internal/services/analytics/analytics_workers_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_workers_test.go
@@ -1,0 +1,53 @@
+package serviceanalytics
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCalculateWorkerCount(t *testing.T) {
+	svc := &AnalyticsDataCenterService{log: getTestLogger()}
+
+	tests := []struct {
+		name   string
+		input  int64
+		expect int64
+	}{
+		{"zero", 0, 1},
+		{"boundary10k", 10000, 1},
+		{"over10k", 10001, 2},
+		{"over100k", 100001, 4},
+		{"over200k", 200001, 6},
+		{"over500k", 500001, 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := svc.calculateWorkerCount(tt.input)
+			require.Equal(t, tt.expect, result)
+		})
+	}
+}
+
+func TestEventIdentifier(t *testing.T) {
+	svc := &AnalyticsDataCenterService{log: getTestLogger()}
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"c", "c"},
+		{"u", "u"},
+		{"d", "d"},
+		{"r", "r"},
+		{"x", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			result := svc.eventIdentifier(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/analytics-data-center/internal/services/cdc/dispatcher_test.go
+++ b/analytics-data-center/internal/services/cdc/dispatcher_test.go
@@ -1,0 +1,40 @@
+package cdc
+
+import (
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type mockHandler struct {
+	called bool
+	event  models.CDCEvent
+}
+
+func (m *mockHandler) EventPreprocessing(evt models.CDCEvent) {
+	m.called = true
+	m.event = evt
+}
+
+func TestDispatch_ValidJSON(t *testing.T) {
+	handler := &mockHandler{}
+	data := []byte(`{"before":null,"after":{"id":1},"source":{"db":"test","schema":"public","table":"users"},"op":"c","transaction":null,"ts_ms":123}`)
+
+	Dispatch(data, handler)
+
+	require.True(t, handler.called, "handler should be called")
+	require.Equal(t, "test", handler.event.Data.Source.DB)
+	require.Equal(t, "users", handler.event.Data.Source.Table)
+	require.Equal(t, "c", handler.event.Data.Op)
+	require.Equal(t, float64(1), handler.event.Data.After["id"])
+}
+
+func TestDispatch_InvalidJSON(t *testing.T) {
+	handler := &mockHandler{}
+	data := []byte("{invalid json}")
+
+	Dispatch(data, handler)
+
+	require.False(t, handler.called, "handler should not be called on invalid JSON")
+}


### PR DESCRIPTION
## Summary
- centralize analytics test mocks in helpers file
- split analytics service tests into focused files

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68401992cb2c8332abf07158d5182db2