### PR TITLE
Add HTTP logging middleware

### DIFF
--- a/analytics-data-center/internal/api/middleware/logger.go
+++ b/analytics-data-center/internal/api/middleware/logger.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Logger is a middleware that logs HTTP requests.
+type Logger struct {
+	log *slog.Logger
+}
+
+// NewLogger creates a new instance of Logger middleware using the provided logger.
+func NewLogger(logger *slog.Logger) *Logger {
+	return &Logger{log: logger}
+}
+
+// Middleware returns a chi compatible middleware handler.
+func (l *Logger) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sr := &statusRecorder{ResponseWriter: w, status: http.StatusOK}
+		start := time.Now()
+
+		next.ServeHTTP(sr, r)
+
+		l.log.Info("request completed",
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+			slog.Int("status", sr.status),
+			slog.Duration("duration", time.Since(start)),
+		)
+	})
+}
+
+// statusRecorder wraps http.ResponseWriter to capture the response status code.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}

--- a/analytics-data-center/internal/api/routes/routes.go
+++ b/analytics-data-center/internal/api/routes/routes.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"analyticDataCenter/analytics-data-center/internal/api/handlers"
 	dbhandlers "analyticDataCenter/analytics-data-center/internal/api/handlers/db_handlers.go"
+	"analyticDataCenter/analytics-data-center/internal/api/middleware"
 	serviceanalytics "analyticDataCenter/analytics-data-center/internal/services/analytics"
 	"log/slog"
 	"net/http"
@@ -16,6 +17,8 @@ func NewRouter(logger *slog.Logger, serviceAnalytics *serviceanalytics.Analytics
 	dbhandlers := dbhandlers.NewDBHandler(logger, serviceAnalytics)
 	handlers := handlers.NewHandlers(logger, dbhandlers)
 
+	logMiddleware := middleware.NewLogger(logger)
+	r.Use(logMiddleware.Middleware)
 	r.Use(cors.Handler(cors.Options{
 		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},


### PR DESCRIPTION
## Summary
- add middleware that logs incoming HTTP requests
- register logger middleware in the HTTP router

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843536aa3e8833290067c6f1c3ed901