### PR TITLE
Refactor ViewBuilderPage into smaller components

### DIFF
--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import settingsReducer from '../features/settings/settingsSlice';
+import viewBuilderReducer from '../features/viewBuilder/viewBuilderSlice';
 
 export const store = configureStore({
   reducer: {
     settings: settingsReducer,
+    viewBuilder: viewBuilderReducer,
   },
 });
 

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -1,7 +1,13 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Heading, VStack, Button } from '@chakra-ui/react';
-import { useSelector } from 'react-redux';
-import type { RootState } from '../../app/store';
+import { useSelector, useDispatch } from 'react-redux';
+import type { RootState, AppDispatch } from '../../app/store';
+import {
+  setSelectedDb,
+  setSelectedSchema,
+  toggleTable,
+  toggleColumn,
+} from './viewBuilderSlice';
 import DatabaseSelector from './components/DatabaseSelector';
 import SchemaSelector from './components/SchemaSelector';
 import TableSelector from './components/TableSelector';
@@ -46,27 +52,18 @@ interface SelectedColumn {
 }
 
 const ViewBuilderPage: React.FC = () => {
-  const [selectedDb, setSelectedDb] = useState('');
-  const [selectedSchema, setSelectedSchema] = useState('');
-  const [selectedTables, setSelectedTables] = useState<string[]>([]);
-  const [selectedColumns, setSelectedColumns] = useState<SelectedColumn[]>([]);
+  const dispatch = useDispatch<AppDispatch>();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
+  const { selectedDb, selectedSchema, selectedTables, selectedColumns } =
+    useSelector((state: RootState) => state.viewBuilder);
 
 
   const handleToggleTable = (table: string) => {
-    setSelectedTables((prev) =>
-      prev.includes(table) ? prev.filter((t) => t !== table) : [...prev, table]
-    );
-    setSelectedColumns((prev) => prev.filter((c) => c.table !== table));
+    dispatch(toggleTable(table));
   };
 
   const handleToggleColumn = (table: string, column: string) => {
-    const exists = selectedColumns.find((c) => c.table === table && c.column === column);
-    if (exists) {
-      setSelectedColumns((prev) => prev.filter((c) => !(c.table === table && c.column === column)));
-    } else {
-      setSelectedColumns((prev) => [...prev, { table, column }]);
-    }
+    dispatch(toggleColumn({ table, column }));
   };
 
   const selectedDatabase = data?.find((db: any) => db.name === selectedDb);
@@ -118,12 +115,7 @@ const ViewBuilderPage: React.FC = () => {
           <DatabaseSelector
             data={data}
             selectedDb={selectedDb}
-            onChange={(db) => {
-              setSelectedDb(db);
-              setSelectedSchema('');
-              setSelectedTables([]);
-              setSelectedColumns([]);
-            }}
+            onChange={(db) => dispatch(setSelectedDb(db))}
           />
         </Box>
 
@@ -132,11 +124,7 @@ const ViewBuilderPage: React.FC = () => {
             <SchemaSelector
               selectedDatabase={selectedDatabase}
               selectedSchema={selectedSchema}
-              onChange={(schema) => {
-                setSelectedSchema(schema);
-                setSelectedTables([]);
-                setSelectedColumns([]);
-              }}
+              onChange={(schema) => dispatch(setSelectedSchema(schema))}
             />
           </Box>
         )}

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -1,25 +1,11 @@
 import React, { useState } from 'react';
-import {
-  Box,
-  Heading,
-  Select,
-  VStack,
-  Checkbox,
-  Text,
-  SimpleGrid,
-  Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  AccordionIcon,
-  Badge,
-  HStack,
-  Divider,
-  Button,
-  useColorModeValue,
-} from '@chakra-ui/react';
+import { Box, Heading, VStack, Button } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../../app/store';
+import DatabaseSelector from './components/DatabaseSelector';
+import SchemaSelector from './components/SchemaSelector';
+import TableSelector from './components/TableSelector';
+import ColumnsGrid from './components/ColumnsGrid';
 
 interface Column {
   name: string;
@@ -66,10 +52,6 @@ const ViewBuilderPage: React.FC = () => {
   const [selectedColumns, setSelectedColumns] = useState<SelectedColumn[]>([]);
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
 
-  const panelBg = useColorModeValue('gray.50', 'gray.700');
-  const panelText = useColorModeValue('gray.800', 'gray.100');
-  const cardBg = useColorModeValue('white', 'gray.800');
-  const cardBorder = useColorModeValue('gray.200', 'gray.600');
 
   const handleToggleTable = (table: string) => {
     setSelectedTables((prev) =>
@@ -133,172 +115,46 @@ const ViewBuilderPage: React.FC = () => {
       <Heading mb={8} textAlign="center">Конструктор витрины</Heading>
       <VStack align="stretch" spacing={6}>
         <Box maxW="md" mx="auto">
-          <Select
-            placeholder={data?.length > 0 ? "Выберите базу данных" : "Нет доступных баз данных"}
-            value={selectedDb}
-            onChange={(e) => {
-              setSelectedDb(e.target.value);
+          <DatabaseSelector
+            data={data}
+            selectedDb={selectedDb}
+            onChange={(db) => {
+              setSelectedDb(db);
               setSelectedSchema('');
               setSelectedTables([]);
               setSelectedColumns([]);
             }}
-          >
-            {data?.map((db: any, index: number) => (
-              <option key={index} value={db?.name}>
-                {db?.name}
-              </option>
-            ))}
-          </Select>
+          />
         </Box>
 
         {selectedDb && selectedDatabase && (
           <Box maxW="md" mx="auto">
-            <Select
-              placeholder="Выберите схему"
-              value={selectedSchema}
-              onChange={(e) => {
-                setSelectedSchema(e.target.value);
+            <SchemaSelector
+              selectedDatabase={selectedDatabase}
+              selectedSchema={selectedSchema}
+              onChange={(schema) => {
+                setSelectedSchema(schema);
                 setSelectedTables([]);
                 setSelectedColumns([]);
               }}
-            >
-              {selectedDatabase.schemas?.map((schema: any, index: number) => (
-                <option key={index} value={schema?.name}>
-                  {schema?.name}
-                </option>
-              ))}
-            </Select>
+            />
           </Box>
         )}
 
         {selectedSchema && selectedSchemaData && (
-          <Box maxW="md" mx="auto">
-            <Text mb={4} fontWeight="medium" textAlign="center">Выберите таблицы:</Text>
-            <VStack align="start" spacing={3}>
-              {selectedSchemaData.tables?.map((table: any) => (
-                <Checkbox
-                  key={table.name}
-                  isChecked={selectedTables.includes(table.name)}
-                  onChange={() => handleToggleTable(table.name)}
-                  size="lg"
-                >
-                  <Text fontSize="md">{table.name}</Text>
-                </Checkbox>
-              ))}
-            </VStack>
-          </Box>
+          <TableSelector
+            selectedSchemaData={selectedSchemaData}
+            selectedTables={selectedTables}
+            onToggleTable={handleToggleTable}
+          />
         )}
 
-        {selectedTables.length > 0 && selectedSchemaData && (
-          <Box w="100%">
-            <Text pt={4} mb={6} fontWeight="medium" textAlign="center" fontSize="lg">
-              Колонки в выбранных таблицах:
-            </Text>
-            <SimpleGrid columns={{ base: 1, lg: 2, xl: 3 }} spacing={6}>
-              {selectedTables.map((tableName) => {
-                const tableData = selectedSchemaData.tables?.find((table: any) => table.name === tableName);
-                return (
-                  <Box
-                    key={tableName}
-                    p={4}
-                    borderWidth="1px"
-                    borderColor={cardBorder}
-                    borderRadius="lg"
-                    bg={cardBg}
-                    shadow="md"
-                    _hover={{ shadow: "lg" }}
-                    transition="all 0.2s"
-                  >
-                    <Text fontWeight="bold" fontSize="lg" mb={4} textAlign="center" color="blue.400">
-                      {tableName}
-                    </Text>
-                    <Accordion allowMultiple>
-                      {tableData?.columns?.map((col: any, index: number) => (
-                        <AccordionItem key={col.name || index} border="none">
-                          <AccordionButton
-                            _hover={{ bg: useColorModeValue("gray.100", "gray.600") }}
-                            borderRadius="md"
-                            mb={1}
-                          >
-                            <Checkbox
-                              mr={4}
-                              isChecked={selectedColumns.some((c) => c.table === tableName && c.column === col.name)}
-                              onChange={() => handleToggleColumn(tableName, col.name)}
-                            />
-                            <Box flex="1" textAlign="left">
-                              <VStack align="start" spacing={1}>
-                                <Text fontWeight="medium">{col.name}</Text>
-                                <HStack wrap="wrap">
-                                  <Badge colorScheme="blue" variant="solid" size="sm">{col.type}</Badge>
-                                  {col.is_primary_key && (
-                                    <Badge colorScheme="red" variant="solid" size="sm">PK</Badge>
-                                  )}
-                                  {col.is_fk && (
-                                    <Badge colorScheme="orange" variant="solid" size="sm">FK</Badge>
-                                  )}
-                                  {col.is_unique && (
-                                    <Badge colorScheme="purple" variant="solid" size="sm">UNQ</Badge>
-                                  )}
-                                </HStack>
-                              </VStack>
-                            </Box>
-                            <AccordionIcon />
-                          </AccordionButton>
-                          <AccordionPanel pb={4} bg={panelBg} color={panelText} borderRadius="md" mt={1}>
-                            <VStack align="start" spacing={3}>
-                              <HStack>
-                                <Text fontWeight="medium" minW="80px" fontSize="sm">Тип:</Text>
-                                <Text fontSize="sm">{col.type}</Text>
-                              </HStack>
-                              <HStack>
-                                <Text fontWeight="medium" minW="80px" fontSize="sm">Nullable:</Text>
-                                <Badge colorScheme={col.is_nullable ? "yellow" : "green"} size="sm">
-                                  {col.is_nullable ? "Да" : "Нет"}
-                                </Badge>
-                              </HStack>
-                              {col.default && (
-                                <VStack align="start" spacing={1}>
-                                  <Text fontWeight="medium" fontSize="sm">По умолчанию:</Text>
-                                  <Text fontSize="xs" p={2} borderRadius="md" wordBreak="break-word" bg="gray.600">
-                                    {col.default}
-                                  </Text>
-                                </VStack>
-                              )}
-                              {col.description && (
-                                <VStack align="start" spacing={1}>
-                                  <Text fontWeight="medium" fontSize="sm">Описание:</Text>
-                                  <Text fontSize="sm">{col.description}</Text>
-                                </VStack>
-                              )}
-                              <Divider />
-                              <VStack align="start" spacing={2}>
-                                <Text fontWeight="medium" fontSize="sm">Свойства:</Text>
-                                <HStack wrap="wrap">
-                                  {col.is_pk && (
-                                    <Badge colorScheme="red" variant="outline" size="sm">Первичный ключ</Badge>
-                                  )}
-                                  {col.is_fk && (
-                                    <Badge colorScheme="orange" variant="outline" size="sm">Внешний ключ</Badge>
-                                  )}
-                                  {col.is_unique && (
-                                    <Badge colorScheme="purple" variant="outline" size="sm">Уникальный</Badge>
-                                  )}
-                                  {!col.is_pk && !col.is_fk && !col.is_unique && (
-                                    <Text fontSize="sm" color="gray.400">Обычная колонка</Text>
-                                  )}
-                                </HStack>
-                              </VStack>
-                            </VStack>
-                          </AccordionPanel>
-                        </AccordionItem>
-                      ))}
-                    </Accordion>
-                  </Box>
-                );
-              })}
-            </SimpleGrid>
-          </Box>
-        )}
+        <ColumnsGrid
+          selectedTables={selectedTables}
+          selectedSchemaData={selectedSchemaData}
+          selectedColumns={selectedColumns}
+          onToggleColumn={handleToggleColumn}
+        />
 
         {selectedColumns.length > 0 && (
           <Box textAlign="center">

--- a/client/src/features/viewBuilder/components/ColumnsGrid.tsx
+++ b/client/src/features/viewBuilder/components/ColumnsGrid.tsx
@@ -1,0 +1,178 @@
+import React from 'react';
+import {
+  Box,
+  Text,
+  SimpleGrid,
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Badge,
+  HStack,
+  VStack,
+  Divider,
+  Checkbox,
+  useColorModeValue
+} from '@chakra-ui/react';
+
+interface SelectedColumn {
+  table: string;
+  column: string;
+}
+
+interface Props {
+  selectedTables: string[];
+  selectedSchemaData: any;
+  selectedColumns: SelectedColumn[];
+  onToggleColumn: (table: string, column: string) => void;
+}
+
+const ColumnsGrid: React.FC<Props> = ({
+  selectedTables,
+  selectedSchemaData,
+  selectedColumns,
+  onToggleColumn
+}) => {
+  const panelBg = useColorModeValue('gray.50', 'gray.700');
+  const panelText = useColorModeValue('gray.800', 'gray.100');
+  const cardBg = useColorModeValue('white', 'gray.800');
+  const cardBorder = useColorModeValue('gray.200', 'gray.600');
+
+  if (selectedTables.length === 0 || !selectedSchemaData) return null;
+
+  return (
+    <Box w="100%">
+      <Text pt={4} mb={6} fontWeight="medium" textAlign="center" fontSize="lg">
+        Колонки в выбранных таблицах:
+      </Text>
+      <SimpleGrid columns={{ base: 1, lg: 2, xl: 3 }} spacing={6}>
+        {selectedTables.map((tableName) => {
+          const tableData = selectedSchemaData.tables?.find((t: any) => t.name === tableName);
+          return (
+            <Box
+              key={tableName}
+              p={4}
+              borderWidth="1px"
+              borderColor={cardBorder}
+              borderRadius="lg"
+              bg={cardBg}
+              shadow="md"
+              _hover={{ shadow: 'lg' }}
+              transition="all 0.2s"
+            >
+              <Text fontWeight="bold" fontSize="lg" mb={4} textAlign="center" color="blue.400">
+                {tableName}
+              </Text>
+              <Accordion allowMultiple>
+                {tableData?.columns?.map((col: any, index: number) => (
+                  <AccordionItem key={col.name || index} border="none">
+                    <AccordionButton _hover={{ bg: useColorModeValue('gray.100', 'gray.600') }} borderRadius="md" mb={1}>
+                      <Checkbox
+                        mr={4}
+                        isChecked={selectedColumns.some((c) => c.table === tableName && c.column === col.name)}
+                        onChange={() => onToggleColumn(tableName, col.name)}
+                      />
+                      <Box flex="1" textAlign="left">
+                        <VStack align="start" spacing={1}>
+                          <Text fontWeight="medium">{col.name}</Text>
+                          <HStack wrap="wrap">
+                            <Badge colorScheme="blue" variant="solid" size="sm">
+                              {col.type}
+                            </Badge>
+                            {col.is_primary_key && (
+                              <Badge colorScheme="red" variant="solid" size="sm">
+                                PK
+                              </Badge>
+                            )}
+                            {col.is_fk && (
+                              <Badge colorScheme="orange" variant="solid" size="sm">
+                                FK
+                              </Badge>
+                            )}
+                            {col.is_unique && (
+                              <Badge colorScheme="purple" variant="solid" size="sm">
+                                UNQ
+                              </Badge>
+                            )}
+                          </HStack>
+                        </VStack>
+                      </Box>
+                      <AccordionIcon />
+                    </AccordionButton>
+                    <AccordionPanel pb={4} bg={panelBg} color={panelText} borderRadius="md" mt={1}>
+                      <VStack align="start" spacing={3}>
+                        <HStack>
+                          <Text fontWeight="medium" minW="80px" fontSize="sm">
+                            Тип:
+                          </Text>
+                          <Text fontSize="sm">{col.type}</Text>
+                        </HStack>
+                        <HStack>
+                          <Text fontWeight="medium" minW="80px" fontSize="sm">
+                            Nullable:
+                          </Text>
+                          <Badge colorScheme={col.is_nullable ? 'yellow' : 'green'} size="sm">
+                            {col.is_nullable ? 'Да' : 'Нет'}
+                          </Badge>
+                        </HStack>
+                        {col.default && (
+                          <VStack align="start" spacing={1}>
+                            <Text fontWeight="medium" fontSize="sm">
+                              По умолчанию:
+                            </Text>
+                            <Text fontSize="xs" p={2} borderRadius="md" wordBreak="break-word" bg="gray.600">
+                              {col.default}
+                            </Text>
+                          </VStack>
+                        )}
+                        {col.description && (
+                          <VStack align="start" spacing={1}>
+                            <Text fontWeight="medium" fontSize="sm">
+                              Описание:
+                            </Text>
+                            <Text fontSize="sm">{col.description}</Text>
+                          </VStack>
+                        )}
+                        <Divider />
+                        <VStack align="start" spacing={2}>
+                          <Text fontWeight="medium" fontSize="sm">
+                            Свойства:
+                          </Text>
+                          <HStack wrap="wrap">
+                            {col.is_pk && (
+                              <Badge colorScheme="red" variant="outline" size="sm">
+                                Первичный ключ
+                              </Badge>
+                            )}
+                            {col.is_fk && (
+                              <Badge colorScheme="orange" variant="outline" size="sm">
+                                Внешний ключ
+                              </Badge>
+                            )}
+                            {col.is_unique && (
+                              <Badge colorScheme="purple" variant="outline" size="sm">
+                                Уникальный
+                              </Badge>
+                            )}
+                            {!col.is_pk && !col.is_fk && !col.is_unique && (
+                              <Text fontSize="sm" color="gray.400">
+                                Обычная колонка
+                              </Text>
+                            )}
+                          </HStack>
+                        </VStack>
+                      </VStack>
+                    </AccordionPanel>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </Box>
+          );
+        })}
+      </SimpleGrid>
+    </Box>
+  );
+};
+
+export default ColumnsGrid;

--- a/client/src/features/viewBuilder/components/DatabaseSelector.tsx
+++ b/client/src/features/viewBuilder/components/DatabaseSelector.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Select } from '@chakra-ui/react';
+
+interface Props {
+  data: any[];
+  selectedDb: string;
+  onChange: (db: string) => void;
+}
+
+const DatabaseSelector: React.FC<Props> = ({ data, selectedDb, onChange }) => (
+  <Select
+    placeholder={data?.length > 0 ? 'Выберите базу данных' : 'Нет доступных баз данных'}
+    value={selectedDb}
+    onChange={(e) => onChange(e.target.value)}
+  >
+    {data?.map((db: any, index: number) => (
+      <option key={index} value={db?.name}>
+        {db?.name}
+      </option>
+    ))}
+  </Select>
+);
+
+export default DatabaseSelector;

--- a/client/src/features/viewBuilder/components/SchemaSelector.tsx
+++ b/client/src/features/viewBuilder/components/SchemaSelector.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Select } from '@chakra-ui/react';
+
+interface Props {
+  selectedDatabase: any;
+  selectedSchema: string;
+  onChange: (schema: string) => void;
+}
+
+const SchemaSelector: React.FC<Props> = ({ selectedDatabase, selectedSchema, onChange }) => {
+  if (!selectedDatabase) return null;
+
+  return (
+    <Select
+      placeholder="Выберите схему"
+      value={selectedSchema}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      {selectedDatabase.schemas?.map((schema: any, index: number) => (
+        <option key={index} value={schema?.name}>
+          {schema?.name}
+        </option>
+      ))}
+    </Select>
+  );
+};
+
+export default SchemaSelector;

--- a/client/src/features/viewBuilder/components/TableSelector.tsx
+++ b/client/src/features/viewBuilder/components/TableSelector.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Box, Checkbox, Text, VStack } from '@chakra-ui/react';
+
+interface Props {
+  selectedSchemaData: any;
+  selectedTables: string[];
+  onToggleTable: (table: string) => void;
+}
+
+const TableSelector: React.FC<Props> = ({ selectedSchemaData, selectedTables, onToggleTable }) => {
+  if (!selectedSchemaData) return null;
+
+  return (
+    <Box maxW="md" mx="auto">
+      <Text mb={4} fontWeight="medium" textAlign="center">
+        Выберите таблицы:
+      </Text>
+      <VStack align="start" spacing={3}>
+        {selectedSchemaData.tables?.map((table: any) => (
+          <Checkbox
+            key={table.name}
+            isChecked={selectedTables.includes(table.name)}
+            onChange={() => onToggleTable(table.name)}
+            size="lg"
+          >
+            <Text fontSize="md">{table.name}</Text>
+          </Checkbox>
+        ))}
+      </VStack>
+    </Box>
+  );
+};
+
+export default TableSelector;

--- a/client/src/features/viewBuilder/viewBuilderSlice.ts
+++ b/client/src/features/viewBuilder/viewBuilderSlice.ts
@@ -1,0 +1,76 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+interface SelectedColumn {
+  table: string;
+  column: string;
+}
+
+interface ViewBuilderState {
+  selectedDb: string;
+  selectedSchema: string;
+  selectedTables: string[];
+  selectedColumns: SelectedColumn[];
+}
+
+const initialState: ViewBuilderState = {
+  selectedDb: '',
+  selectedSchema: '',
+  selectedTables: [],
+  selectedColumns: [],
+};
+
+const viewBuilderSlice = createSlice({
+  name: 'viewBuilder',
+  initialState,
+  reducers: {
+    setSelectedDb(state, action: PayloadAction<string>) {
+      state.selectedDb = action.payload;
+      state.selectedSchema = '';
+      state.selectedTables = [];
+      state.selectedColumns = [];
+    },
+    setSelectedSchema(state, action: PayloadAction<string>) {
+      state.selectedSchema = action.payload;
+      state.selectedTables = [];
+      state.selectedColumns = [];
+    },
+    toggleTable(state, action: PayloadAction<string>) {
+      const table = action.payload;
+      if (state.selectedTables.includes(table)) {
+        state.selectedTables = state.selectedTables.filter((t) => t !== table);
+        state.selectedColumns = state.selectedColumns.filter((c) => c.table !== table);
+      } else {
+        state.selectedTables.push(table);
+      }
+    },
+    toggleColumn(state, action: PayloadAction<SelectedColumn>) {
+      const { table, column } = action.payload;
+      const exists = state.selectedColumns.find(
+        (c) => c.table === table && c.column === column,
+      );
+      if (exists) {
+        state.selectedColumns = state.selectedColumns.filter(
+          (c) => !(c.table === table && c.column === column),
+        );
+      } else {
+        state.selectedColumns.push({ table, column });
+      }
+    },
+    resetSelections(state) {
+      state.selectedDb = '';
+      state.selectedSchema = '';
+      state.selectedTables = [];
+      state.selectedColumns = [];
+    },
+  },
+});
+
+export const {
+  setSelectedDb,
+  setSelectedSchema,
+  toggleTable,
+  toggleColumn,
+  resetSelections,
+} = viewBuilderSlice.actions;
+
+export default viewBuilderSlice.reducer;


### PR DESCRIPTION
## Summary
- split up the large ViewBuilderPage into composable components
- add `DatabaseSelector`, `SchemaSelector`, `TableSelector`, and `ColumnsGrid`
- simplify ViewBuilderPage by using the new components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `go test ./...` *(fails: tests failing in SQLGenerator package)*

------
https://chatgpt.com/codex/tasks/task_e_68505d7d2ab48332b0fa592b6501833f