### PR TITLE
Add join builder page

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.10.9",
         "@chakra-ui/theme": "^3.4.6",
         "@emotion/react": "^11.14.0",
@@ -347,6 +348,16 @@
         "framesync": "6.1.2"
       },
       "peerDependencies": {
+        "react": ">=18"
+      }
+    },
+    "node_modules/@chakra-ui/icons": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/icons/-/icons-2.2.4.tgz",
+      "integrity": "sha512-l5QdBgwrAg3Sc2BRqtNkJpfuLw/pWRDwwT58J6c4PqQT6wzXxyNa8Q0PForu1ltB5qEiFb1kxr/F/HO1EwNa6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@chakra-ui/react": ">=2.0.0",
         "react": ">=18"
       }
     },

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.10.9",
     "@chakra-ui/theme": "^3.4.6",
     "@emotion/react": "^11.14.0",

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import SettingsPage from './features/settings/SettingsPage';
 import { Box, Flex } from '@chakra-ui/react';
 import ThemeToggle from './components/ThemeToggle';
 import ViewBuilderPage from './features/viewBuilder/ViewBuilderPage';
+import JoinBuilderPage from './features/viewBuilder/JoinBuilderPage';
 
 const App: React.FC = () => {
   return (
@@ -15,6 +16,7 @@ const App: React.FC = () => {
       <Routes>
         <Route path="/settings" element={<SettingsPage />} />
         <Route path='/builder' element={<ViewBuilderPage/>}></Route>
+        <Route path='/joins' element={<JoinBuilderPage/>}></Route>
         <Route path="*" element={<Navigate to="/settings" replace />} />
       </Routes>
     </Box>

--- a/client/src/features/viewBuilder/JoinBuilderPage.tsx
+++ b/client/src/features/viewBuilder/JoinBuilderPage.tsx
@@ -1,0 +1,201 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  VStack,
+  HStack,
+  Select,
+  Button,
+  Text,
+  Input,
+  List,
+  ListItem,
+  IconButton,
+} from '@chakra-ui/react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import type { RootState, AppDispatch } from '../../app/store';
+import { addJoin, removeJoin, setViewName } from './viewBuilderSlice';
+import { useHttp } from '../../hooks/http.hook';
+import { DeleteIcon } from '@chakra-ui/icons';
+
+interface Column {
+  name: string;
+}
+
+const JoinBuilderPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const { request } = useHttp();
+
+  const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
+  const {
+    selectedDb,
+    selectedSchema,
+    selectedTables,
+    selectedColumns,
+    joins,
+    viewName,
+  } = useSelector((state: RootState) => state.viewBuilder);
+
+  const selectedDatabase = data?.find((db: any) => db.name === selectedDb);
+  const selectedSchemaData = selectedDatabase?.schemas?.find((s: any) => s.name === selectedSchema);
+
+  const [mainTable, setMainTable] = useState('');
+  const [joinTable, setJoinTable] = useState('');
+  const [mainColumn, setMainColumn] = useState('');
+  const [joinColumn, setJoinColumn] = useState('');
+
+  const handleAddJoin = () => {
+    if (!mainTable || !joinTable || !mainColumn || !joinColumn) return;
+    const join = {
+      inner: {
+        source: selectedDb,
+        schema: selectedSchema,
+        table: joinTable,
+        main_table: mainTable,
+        column_first: mainColumn,
+        column_second: joinColumn,
+      },
+    };
+    dispatch(addJoin(join));
+    setJoinTable('');
+    setMainColumn('');
+    setJoinColumn('');
+  };
+
+  const handleCreateView = async () => {
+    if (!selectedSchemaData) return;
+    const source = {
+      name: selectedDb,
+      schemas: [
+        {
+          name: selectedSchema,
+          tables: selectedTables.map((tableName) => {
+            const tableData = selectedSchemaData.tables.find((t: any) => t.name === tableName);
+            return {
+              name: tableName,
+              columns: tableData.columns
+                .filter((col: Column) =>
+                  selectedColumns.some((c) => c.table === tableName && c.column === col.name)
+                )
+                .map((col: any) => ({
+                  name: col.name,
+                  type: col.type,
+                  is_nullable: col.is_nullable,
+                  is_primary_key: col.is_primary_key || col.is_pk,
+                  is_fk: col.is_fk,
+                  default: col.default,
+                  is_unq: col.is_unique,
+                  view_key: col.view_key,
+                  is_update_key: col.is_update_key,
+                })),
+            };
+          }),
+        },
+      ],
+    };
+
+    const view = {
+      view_name: viewName,
+      sources: [source],
+      joins,
+    };
+
+    try {
+      await request('http://localhost:8888/api/upload-schem', 'POST', view);
+      navigate('/settings');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const getColumnsForTable = (tableName: string): Column[] => {
+    const table = selectedSchemaData?.tables.find((t: any) => t.name === tableName);
+    return table ? table.columns : [];
+  };
+
+  return (
+    <Box p={8} maxW="800px" mx="auto">
+      <Heading mb={8} textAlign="center">
+        Настройка джоинов
+      </Heading>
+      <VStack spacing={4} align="stretch">
+        <Box>
+          {selectedTables.map((table) => (
+            <Box key={table} mb={2}>
+              <Text fontWeight="bold">{table}</Text>
+              <List pl={4} styleType="disc">
+                {selectedColumns
+                  .filter((c) => c.table === table)
+                  .map((c) => (
+                    <ListItem key={c.column}>{c.column}</ListItem>
+                  ))}
+              </List>
+            </Box>
+          ))}
+        </Box>
+        <Input
+          placeholder="Имя витрины"
+          value={viewName}
+          onChange={(e) => dispatch(setViewName(e.target.value))}
+        />
+        <HStack>
+          <Select placeholder="Основная таблица" value={mainTable} onChange={(e) => setMainTable(e.target.value)}>
+            {selectedTables.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </Select>
+          <Select placeholder="Колонка" value={mainColumn} onChange={(e) => setMainColumn(e.target.value)}>
+            {getColumnsForTable(mainTable).map((col) => (
+              <option key={col.name} value={col.name}>
+                {col.name}
+              </option>
+            ))}
+          </Select>
+        </HStack>
+        <HStack>
+          <Select placeholder="Таблица для join" value={joinTable} onChange={(e) => setJoinTable(e.target.value)}>
+            {selectedTables.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </Select>
+          <Select placeholder="Колонка" value={joinColumn} onChange={(e) => setJoinColumn(e.target.value)}>
+            {getColumnsForTable(joinTable).map((col) => (
+              <option key={col.name} value={col.name}>
+                {col.name}
+              </option>
+            ))}
+          </Select>
+        </HStack>
+        <Button onClick={handleAddJoin} colorScheme="teal" alignSelf="flex-start">
+          Добавить join
+        </Button>
+
+        <List spacing={3} w="100%">
+          {joins.map((j, idx) => (
+            <ListItem key={idx} display="flex" alignItems="center" justifyContent="space-between">
+              <Text>{`${j.inner.main_table}.${j.inner.column_first} = ${j.inner.table}.${j.inner.column_second}`}</Text>
+              <IconButton
+                aria-label="delete"
+                icon={<DeleteIcon />}
+                size="sm"
+                onClick={() => dispatch(removeJoin(idx))}
+              />
+            </ListItem>
+          ))}
+        </List>
+
+        <Button colorScheme="blue" onClick={handleCreateView} alignSelf="center">
+          Создать витрину
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default JoinBuilderPage;

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Box, Heading, VStack, Button } from '@chakra-ui/react';
 import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../../app/store';
 import {
   setSelectedDb,
@@ -13,46 +14,9 @@ import SchemaSelector from './components/SchemaSelector';
 import TableSelector from './components/TableSelector';
 import ColumnsGrid from './components/ColumnsGrid';
 
-interface Column {
-  name: string;
-  type?: string;
-  is_nullable?: boolean;
-  is_primary_key?: boolean;
-  is_pk?: boolean;
-  is_fk?: boolean;
-  default?: string;
-  is_unique?: boolean;
-  description?: string;
-}
-
-interface Table {
-  name: string;
-  columns: Column[];
-}
-
-interface Schema {
-  name: string;
-  tables: Table[];
-}
-
-interface Source {
-  name: string;
-  schemas: Schema[];
-}
-
-interface View {
-  view_name: string;
-  sources: Source[];
-  joins: any[];
-}
-
-interface SelectedColumn {
-  table: string;
-  column: string;
-}
-
 const ViewBuilderPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
   const { selectedDb, selectedSchema, selectedTables, selectedColumns } =
     useSelector((state: RootState) => state.viewBuilder);
@@ -70,41 +34,7 @@ const ViewBuilderPage: React.FC = () => {
   const selectedSchemaData = selectedDatabase?.schemas?.find((schema: any) => schema.name === selectedSchema);
 
   const handleBuildView = () => {
-    const source: Source = {
-      name: selectedDb,
-      schemas: [
-        {
-          name: selectedSchema,
-          tables: selectedTables.map((tableName) => {
-            const tableData = selectedSchemaData.tables.find((t: any) => t.name === tableName);
-            return {
-              name: tableName,
-              columns: tableData.columns
-                .filter((col: any) =>
-                  selectedColumns.some((c) => c.table === tableName && c.column === col.name)
-                )
-                .map((col: any) => ({
-                  name: col.name,
-                  type: col.type,
-                  is_nullable: col.is_nullable,
-                  is_primary_key: col.is_primary_key || col.is_pk,
-                  is_fk: col.is_fk,
-                  default: col.default,
-                  is_unq: col.is_unique,
-                })),
-            };
-          }),
-        },
-      ],
-    };
-
-    const view: View = {
-      view_name: 'MyView',
-      sources: [source],
-      joins: [],
-    };
-
-    console.log('Собранная витрина:', view);
+    navigate('/joins');
   };
 
   return (

--- a/client/src/features/viewBuilder/viewBuilderSlice.ts
+++ b/client/src/features/viewBuilder/viewBuilderSlice.ts
@@ -5,11 +5,26 @@ interface SelectedColumn {
   column: string;
 }
 
+interface JoinSide {
+  source: string;
+  schema: string;
+  table: string;
+  main_table: string;
+  column_first: string;
+  column_second: string;
+}
+
+interface Join {
+  inner: JoinSide;
+}
+
 interface ViewBuilderState {
   selectedDb: string;
   selectedSchema: string;
   selectedTables: string[];
   selectedColumns: SelectedColumn[];
+  joins: Join[];
+  viewName: string;
 }
 
 const initialState: ViewBuilderState = {
@@ -17,9 +32,11 @@ const initialState: ViewBuilderState = {
   selectedSchema: '',
   selectedTables: [],
   selectedColumns: [],
+  joins: [],
+  viewName: 'MyView',
 };
 
-const viewBuilderSlice = createSlice({
+const viewBuilderSlice = createSlice<ViewBuilderState>({
   name: 'viewBuilder',
   initialState,
   reducers: {
@@ -56,11 +73,22 @@ const viewBuilderSlice = createSlice({
         state.selectedColumns.push({ table, column });
       }
     },
+    addJoin(state, action: PayloadAction<Join>) {
+      state.joins.push(action.payload);
+    },
+    removeJoin(state, action: PayloadAction<number>) {
+      state.joins.splice(action.payload, 1);
+    },
+    setViewName(state, action: PayloadAction<string>) {
+      state.viewName = action.payload;
+    },
     resetSelections(state) {
       state.selectedDb = '';
       state.selectedSchema = '';
       state.selectedTables = [];
       state.selectedColumns = [];
+      state.joins = [];
+      state.viewName = 'MyView';
     },
   },
 });
@@ -70,6 +98,9 @@ export const {
   setSelectedSchema,
   toggleTable,
   toggleColumn,
+  addJoin,
+  removeJoin,
+  setViewName,
   resetSelections,
 } = viewBuilderSlice.actions;
 


### PR DESCRIPTION
## Summary
- extend viewBuilder slice with joins and view name
- add JoinBuilderPage for configuring joins and posting view
- update builder page to navigate to join configuration
- add route for join builder
- include chakra icons package

## Testing
- `npm install`
- `npm run build` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685275dbc1f483328dbf6de22349f89c