### PR TITLE
Add transformations setup and navigation menu

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,8 +3,10 @@ import { Routes, Route, Navigate } from 'react-router-dom';
 import SettingsPage from './features/settings/SettingsPage';
 import { Box, Flex } from '@chakra-ui/react';
 import ThemeToggle from './components/ThemeToggle';
+import NavigationMenu from './components/NavigationMenu';
 import ViewBuilderPage from './features/viewBuilder/ViewBuilderPage';
 import JoinBuilderPage from './features/viewBuilder/JoinBuilderPage';
+import TransformBuilderPage from './features/viewBuilder/TransformBuilderPage';
 
 const App: React.FC = () => {
   return (
@@ -12,11 +14,13 @@ const App: React.FC = () => {
       <Flex justify="flex-end" p={4}>
         <ThemeToggle />
       </Flex>
+      <NavigationMenu />
 
       <Routes>
         <Route path="/settings" element={<SettingsPage />} />
         <Route path='/builder' element={<ViewBuilderPage/>}></Route>
         <Route path='/joins' element={<JoinBuilderPage/>}></Route>
+        <Route path='/transforms' element={<TransformBuilderPage/>}></Route>
         <Route path="*" element={<Navigate to="/settings" replace />} />
       </Routes>
     </Box>

--- a/client/src/components/NavigationMenu.tsx
+++ b/client/src/components/NavigationMenu.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { HStack, Button } from '@chakra-ui/react';
+import { NavLink } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../app/store';
+
+const NavigationMenu: React.FC = () => {
+  const settings = useSelector((state: RootState) => state.settings);
+  const builder = useSelector((state: RootState) => state.viewBuilder);
+
+  const canBuilder = !!settings.dataBaseInfo;
+  const canJoins = builder.selectedColumns.length > 0;
+  const canTransforms = canJoins;
+
+  const links = [
+    { label: 'Подключение', path: '/settings', enabled: true },
+    { label: 'Таблицы', path: '/builder', enabled: canBuilder },
+    { label: 'Джоины', path: '/joins', enabled: canJoins },
+    { label: 'Трансформации', path: '/transforms', enabled: canTransforms },
+  ];
+
+  return (
+    <HStack spacing={4} justify="center" mb={4}>
+      {links.map((link) => (
+        <Button
+          as={NavLink}
+          key={link.path}
+          to={link.path}
+          variant="outline"
+          colorScheme="teal"
+          isDisabled={!link.enabled}
+        >
+          {link.label}
+        </Button>
+      ))}
+    </HStack>
+  );
+};
+
+export default NavigationMenu;

--- a/client/src/features/viewBuilder/JoinBuilderPage.tsx
+++ b/client/src/features/viewBuilder/JoinBuilderPage.tsx
@@ -16,7 +16,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../../app/store';
 import { addJoin, removeJoin, setViewName } from './viewBuilderSlice';
-import { useHttp } from '../../hooks/http.hook';
 import { DeleteIcon } from '@chakra-ui/icons';
 
 interface Column {
@@ -26,7 +25,6 @@ interface Column {
 const JoinBuilderPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
-  const { request } = useHttp();
 
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
   const {
@@ -64,50 +62,8 @@ const JoinBuilderPage: React.FC = () => {
     setJoinColumn('');
   };
 
-  const handleCreateView = async () => {
-    if (!selectedSchemaData) return;
-    const source = {
-      name: selectedDb,
-      schemas: [
-        {
-          name: selectedSchema,
-          tables: selectedTables.map((tableName) => {
-            const tableData = selectedSchemaData.tables.find((t: any) => t.name === tableName);
-            return {
-              name: tableName,
-              columns: tableData.columns
-                .filter((col: Column) =>
-                  selectedColumns.some((c) => c.table === tableName && c.column === col.name)
-                )
-                .map((col: any) => ({
-                  name: col.name,
-                  type: col.type,
-                  is_nullable: col.is_nullable,
-                  is_primary_key: col.is_primary_key || col.is_pk,
-                  is_fk: col.is_fk,
-                  default: col.default,
-                  is_unq: col.is_unique,
-                  view_key: col.view_key,
-                  is_update_key: col.is_update_key,
-                })),
-            };
-          }),
-        },
-      ],
-    };
-
-    const view = {
-      view_name: viewName,
-      sources: [source],
-      joins,
-    };
-
-    try {
-      await request('http://localhost:8888/api/upload-schem', 'POST', view);
-      navigate('/settings');
-    } catch (e) {
-      console.error(e);
-    }
+  const handleNext = () => {
+    navigate('/transforms');
   };
 
   const getColumnsForTable = (tableName: string): Column[] => {
@@ -190,8 +146,8 @@ const JoinBuilderPage: React.FC = () => {
           ))}
         </List>
 
-        <Button colorScheme="blue" onClick={handleCreateView} alignSelf="center">
-          Создать витрину
+        <Button colorScheme="blue" onClick={handleNext} alignSelf="center">
+          Далее
         </Button>
       </VStack>
     </Box>

--- a/client/src/features/viewBuilder/TransformBuilderPage.tsx
+++ b/client/src/features/viewBuilder/TransformBuilderPage.tsx
@@ -1,0 +1,186 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  VStack,
+  Select,
+  Input,
+  Textarea,
+  Button,
+  Text,
+  Divider,
+} from '@chakra-ui/react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import type { RootState, AppDispatch } from '../../app/store';
+import { setTransformation } from './viewBuilderSlice';
+import { useHttp } from '../../hooks/http.hook';
+
+interface LocalTransformState {
+  type: string;
+  output: string;
+  mapping: string;
+  mappingJson: string;
+}
+
+const TransformBuilderPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const navigate = useNavigate();
+  const { request } = useHttp();
+
+  const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
+  const {
+    selectedDb,
+    selectedSchema,
+    selectedTables,
+    selectedColumns,
+    joins,
+    viewName,
+    transformations,
+  } = useSelector((state: RootState) => state.viewBuilder);
+
+  const selectedDatabase = data?.find((db: any) => db.name === selectedDb);
+  const selectedSchemaData = selectedDatabase?.schemas?.find((s: any) => s.name === selectedSchema);
+
+  const initial: Record<string, LocalTransformState> = {};
+  selectedColumns.forEach((c) => {
+    const key = `${c.table}.${c.column}`;
+    const existing = transformations[key];
+    initial[key] = {
+      type: existing?.type || '',
+      output: existing?.output_column || '',
+      mapping: existing?.mapping?.mapping ? JSON.stringify(existing.mapping.mapping, null, 2) : '',
+      mappingJson: existing?.mapping?.mapping_json ? JSON.stringify(existing.mapping.mapping_json, null, 2) : '',
+    };
+  });
+
+  const [local, setLocal] = useState<Record<string, LocalTransformState>>(initial);
+
+  const updateField = (key: string, field: keyof LocalTransformState, value: string) => {
+    setLocal((prev) => ({ ...prev, [key]: { ...prev[key], [field]: value } }));
+  };
+
+  const handleSave = async () => {
+    Object.entries(local).forEach(([key, val]) => {
+      const [table, column] = key.split('.');
+      if (!val.type) {
+        dispatch(setTransformation({ table, column, transform: null }));
+        return;
+      }
+      let mapping: any = {};
+      if (val.type === 'FieldTransform' && val.mapping) {
+        try {
+          mapping = { type_map: 'FieldTransform', alias_new_column_transform: val.output, mapping: JSON.parse(val.mapping) };
+        } catch {}
+      }
+      if (val.type === 'JSON' && val.mappingJson) {
+        try {
+          mapping = { type_map: 'JSON', mapping_json: JSON.parse(val.mappingJson) };
+        } catch {}
+      }
+      const transform = {
+        type: val.type,
+        mode: 'Mapping',
+        output_column: val.output || column,
+        mapping,
+      };
+      dispatch(setTransformation({ table, column, transform }));
+    });
+
+    if (!selectedSchemaData) return;
+    const source = {
+      name: selectedDb,
+      schemas: [
+        {
+          name: selectedSchema,
+          tables: selectedTables.map((tableName) => {
+            const tableData = selectedSchemaData.tables.find((t: any) => t.name === tableName);
+            return {
+              name: tableName,
+              columns: tableData.columns
+                .filter((col: any) => selectedColumns.some((c) => c.table === tableName && c.column === col.name))
+                .map((col: any) => {
+                  const key = `${tableName}.${col.name}`;
+                  const base = {
+                    name: col.name,
+                    type: col.type,
+                    is_nullable: col.is_nullable,
+                    is_primary_key: col.is_primary_key || col.is_pk,
+                    is_fk: col.is_fk,
+                    default: col.default,
+                    is_unq: col.is_unique,
+                    view_key: col.view_key,
+                    is_update_key: col.is_update_key,
+                  };
+                  const tr = transformations[key];
+                  return tr ? { ...base, transform: tr } : base;
+                }),
+            };
+          }),
+        },
+      ],
+    };
+
+    const view = {
+      view_name: viewName,
+      sources: [source],
+      joins,
+    };
+
+    try {
+      await request('http://localhost:8888/api/upload-schem', 'POST', view);
+      navigate('/settings');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  const renderColumn = (table: string, column: any) => {
+    const key = `${table}.${column.name}`;
+    if (!local[key]) return null;
+    const val = local[key];
+    return (
+      <Box key={key} p={4} borderWidth="1px" borderRadius="md" mb={4}
+           background="gray.700">
+        <Text mb={2} fontWeight="bold">{table}.{column.name}</Text>
+        <Select mb={2} value={val.type} onChange={(e) => updateField(key, 'type', e.target.value)}>
+          <option value="">Без трансформации</option>
+          <option value="FieldTransform">FieldTransform</option>
+          <option value="JSON">JSON</option>
+        </Select>
+        <Input mb={2} placeholder="Output column" value={val.output} onChange={(e) => updateField(key, 'output', e.target.value)} />
+        {val.type === 'FieldTransform' && (
+          <Textarea mb={2} placeholder='{"1":"A"}' value={val.mapping} onChange={(e) => updateField(key, 'mapping', e.target.value)} />
+        )}
+        {val.type === 'JSON' && (
+          <Textarea mb={2} placeholder='[{"type_field":"int","mapping":{"json_field":"out_col"}}]' value={val.mappingJson} onChange={(e) => updateField(key, 'mappingJson', e.target.value)} />
+        )}
+      </Box>
+    );
+  };
+
+  return (
+    <Box p={8} maxW="900px" mx="auto">
+      <Heading mb={8} textAlign="center">Трансформации</Heading>
+      <VStack align="stretch" spacing={4}>
+        {selectedTables.map((tableName) => {
+          const tableData = selectedSchemaData?.tables.find((t: any) => t.name === tableName);
+          return (
+            <Box key={tableName}>
+              <Text fontSize="lg" fontWeight="bold" mb={2}>{tableName}</Text>
+              <Divider mb={2} />
+              {tableData?.columns
+                .filter((col: any) => selectedColumns.some((c) => c.table === tableName && c.column === col.name))
+                .map((col: any) => renderColumn(tableName, col))}
+            </Box>
+          );
+        })}
+        <Button colorScheme="blue" onClick={handleSave} alignSelf="center">
+          Создать витрину
+        </Button>
+      </VStack>
+    </Box>
+  );
+};
+
+export default TransformBuilderPage;

--- a/client/src/features/viewBuilder/viewBuilderSlice.ts
+++ b/client/src/features/viewBuilder/viewBuilderSlice.ts
@@ -25,6 +25,27 @@ interface ViewBuilderState {
   selectedColumns: SelectedColumn[];
   joins: Join[];
   viewName: string;
+  transformations: Record<string, Transform>;
+}
+
+export interface MappingJSON {
+  mapping: Record<string, string>;
+  type_field: string;
+}
+
+export interface Mapping {
+  type_map?: string;
+  mapping?: Record<string, string>;
+  alias_new_column_transform?: string;
+  type_field?: string;
+  mapping_json?: MappingJSON[];
+}
+
+export interface Transform {
+  type: string;
+  mode: string;
+  output_column: string;
+  mapping: Mapping;
 }
 
 const initialState: ViewBuilderState = {
@@ -34,9 +55,10 @@ const initialState: ViewBuilderState = {
   selectedColumns: [],
   joins: [],
   viewName: 'MyView',
+  transformations: {},
 };
 
-const viewBuilderSlice = createSlice<ViewBuilderState>({
+const viewBuilderSlice = createSlice({
   name: 'viewBuilder',
   initialState,
   reducers: {
@@ -79,6 +101,17 @@ const viewBuilderSlice = createSlice<ViewBuilderState>({
     removeJoin(state, action: PayloadAction<number>) {
       state.joins.splice(action.payload, 1);
     },
+    setTransformation(
+      state,
+      action: PayloadAction<{ table: string; column: string; transform: Transform | null }>,
+    ) {
+      const key = `${action.payload.table}.${action.payload.column}`;
+      if (action.payload.transform) {
+        state.transformations[key] = action.payload.transform;
+      } else {
+        delete state.transformations[key];
+      }
+    },
     setViewName(state, action: PayloadAction<string>) {
       state.viewName = action.payload;
     },
@@ -89,6 +122,7 @@ const viewBuilderSlice = createSlice<ViewBuilderState>({
       state.selectedColumns = [];
       state.joins = [];
       state.viewName = 'MyView';
+      state.transformations = {};
     },
   },
 });
@@ -100,6 +134,7 @@ export const {
   toggleColumn,
   addJoin,
   removeJoin,
+  setTransformation,
   setViewName,
   resetSelections,
 } = viewBuilderSlice.actions;


### PR DESCRIPTION
## Summary
- add navigation menu to switch between setup steps
- implement transformations page with schema upload
- track transformations in Redux slice
- update join page to navigate to transforms

## Testing
- `go test ./...`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68527c5914308332a6b5eda62dab42f6