### PR TITLE
Add summary page and view_key selection

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,7 @@ import NavigationMenu from './components/NavigationMenu';
 import ViewBuilderPage from './features/viewBuilder/ViewBuilderPage';
 import JoinBuilderPage from './features/viewBuilder/JoinBuilderPage';
 import TransformBuilderPage from './features/viewBuilder/TransformBuilderPage';
+import SummaryPage from './features/summary/SummaryPage';
 
 const App: React.FC = () => {
   return (
@@ -21,6 +22,7 @@ const App: React.FC = () => {
         <Route path='/builder' element={<ViewBuilderPage/>}></Route>
         <Route path='/joins' element={<JoinBuilderPage/>}></Route>
         <Route path='/transforms' element={<TransformBuilderPage/>}></Route>
+        <Route path='/summary' element={<SummaryPage/>}></Route>
         <Route path="*" element={<Navigate to="/settings" replace />} />
       </Routes>
     </Box>

--- a/client/src/components/NavigationMenu.tsx
+++ b/client/src/components/NavigationMenu.tsx
@@ -11,12 +11,14 @@ const NavigationMenu: React.FC = () => {
   const canBuilder = !!settings.dataBaseInfo;
   const canJoins = builder.selectedColumns.length > 0;
   const canTransforms = canJoins;
+  const canSummary = canTransforms;
 
   const links = [
     { label: 'Подключение', path: '/settings', enabled: true },
     { label: 'Таблицы', path: '/builder', enabled: canBuilder },
     { label: 'Джоины', path: '/joins', enabled: canJoins },
     { label: 'Трансформации', path: '/transforms', enabled: canTransforms },
+    { label: 'Итог', path: '/summary', enabled: canSummary },
   ];
 
   return (

--- a/client/src/features/summary/SummaryPage.tsx
+++ b/client/src/features/summary/SummaryPage.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+import { useSelector } from 'react-redux';
+import type { RootState } from '../../app/store';
+import ViewPreview from './components/ViewPreview';
+import SummaryActions from './components/SummaryActions';
+
+const SummaryPage: React.FC = () => {
+  const settings = useSelector((state: RootState) => state.settings);
+  const builder = useSelector((state: RootState) => state.viewBuilder);
+
+  const data = settings.dataBaseInfo;
+
+  const selectedDatabase = data?.find((db: any) => db.name === builder.selectedDb);
+  const selectedSchemaData = selectedDatabase?.schemas?.find((s: any) => s.name === builder.selectedSchema);
+
+  if (!selectedSchemaData) return null;
+
+  const source = {
+    name: builder.selectedDb,
+    schemas: [
+      {
+        name: builder.selectedSchema,
+        tables: builder.selectedTables.map((tableName) => {
+          const tableData = selectedSchemaData.tables.find((t: any) => t.name === tableName);
+          return {
+            name: tableName,
+            columns: tableData.columns
+              .filter((col: any) => builder.selectedColumns.some((c) => c.table === tableName && c.column === col.name))
+              .map((col: any) => {
+                const key = `${tableName}.${col.name}`;
+                const base = {
+                  name: col.name,
+                  type: col.type,
+                  is_nullable: col.is_nullable,
+                  is_primary_key: col.is_primary_key || col.is_pk,
+                  is_fk: col.is_fk,
+                  default: col.default,
+                  is_unq: col.is_unique,
+                  view_key:
+                    builder.selectedColumns.find((c) => c.table === tableName && c.column === col.name)?.viewKey ||
+                    col.view_key,
+                  is_update_key: col.is_update_key,
+                };
+                const tr = builder.transformations[key];
+                return tr ? { ...base, transform: tr } : base;
+              }),
+          };
+        }),
+      },
+    ],
+  };
+
+  const view = {
+    view_name: builder.viewName,
+    sources: [source],
+    joins: builder.joins,
+  };
+
+  return (
+    <Box p={8} maxW="900px" mx="auto">
+      <Heading mb={4} textAlign="center">
+        Итоговая схема
+      </Heading>
+      <ViewPreview view={view} />
+      <SummaryActions view={view} />
+    </Box>
+  );
+};
+
+export default SummaryPage;

--- a/client/src/features/summary/components/SummaryActions.tsx
+++ b/client/src/features/summary/components/SummaryActions.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Button } from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import { useHttp } from '../../../hooks/http.hook';
+
+interface Props {
+  view: any; // TODO: define proper type
+}
+
+const SummaryActions: React.FC<Props> = ({ view }) => {
+  const navigate = useNavigate();
+  const { request } = useHttp();
+
+  const handleSend = async () => {
+    try {
+      await request('http://localhost:8888/api/upload-schem', 'POST', view);
+      navigate('/settings');
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return (
+    <>
+      <Button colorScheme="teal" onClick={handleSend} mr={4}>
+        Отправить
+      </Button>
+      <Button onClick={() => navigate('/transforms')}>Назад</Button>
+    </>
+  );
+};
+
+export default SummaryActions;

--- a/client/src/features/summary/components/ViewPreview.tsx
+++ b/client/src/features/summary/components/ViewPreview.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { Textarea } from '@chakra-ui/react';
+
+interface Props {
+  view: any; // TODO: define proper type
+}
+
+const ViewPreview: React.FC<Props> = ({ view }) => (
+  <Textarea value={JSON.stringify(view, null, 2)} readOnly h="400px" mb={4} />
+);
+
+export default ViewPreview;

--- a/client/src/features/viewBuilder/viewBuilderSlice.ts
+++ b/client/src/features/viewBuilder/viewBuilderSlice.ts
@@ -3,6 +3,7 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 interface SelectedColumn {
   table: string;
   column: string;
+  viewKey?: string;
 }
 
 interface JoinSide {
@@ -84,15 +85,25 @@ const viewBuilderSlice = createSlice({
     },
     toggleColumn(state, action: PayloadAction<SelectedColumn>) {
       const { table, column } = action.payload;
-      const exists = state.selectedColumns.find(
+      const idx = state.selectedColumns.findIndex(
         (c) => c.table === table && c.column === column,
       );
-      if (exists) {
-        state.selectedColumns = state.selectedColumns.filter(
-          (c) => !(c.table === table && c.column === column),
-        );
+      if (idx !== -1) {
+        state.selectedColumns.splice(idx, 1);
       } else {
         state.selectedColumns.push({ table, column });
+      }
+    },
+    setViewKey(
+      state,
+      action: PayloadAction<{ table: string; column: string; viewKey: string }>,
+    ) {
+      const { table, column, viewKey } = action.payload;
+      const col = state.selectedColumns.find(
+        (c) => c.table === table && c.column === column,
+      );
+      if (col) {
+        col.viewKey = viewKey || undefined;
       }
     },
     addJoin(state, action: PayloadAction<Join>) {
@@ -132,6 +143,7 @@ export const {
   setSelectedSchema,
   toggleTable,
   toggleColumn,
+  setViewKey,
   addJoin,
   removeJoin,
   setTransformation,


### PR DESCRIPTION
## Summary
- allow specifying `view_key` for selected columns
- add final summary page with JSON preview
- navigate to summary page and update navigation menu
- refactor summary page into separate components for clarity

## Testing
- `npm run build`
- `npm run lint` *(fails: React hook warnings and explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68528a2bc0b4833292c9f2ba77b4b8ec