### PR TITLE
Add tasks viewer page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,6 +9,7 @@ import JoinBuilderPage from './features/viewBuilder/JoinBuilderPage';
 import TransformBuilderPage from './features/viewBuilder/TransformBuilderPage';
 import SummaryPage from './features/summary/SummaryPage';
 import DatabaseViewerPage from './features/dbViewer/DatabaseViewerPage';
+import TasksPage from './features/tasks/TasksPage';
 
 const App: React.FC = () => {
   return (
@@ -21,6 +22,7 @@ const App: React.FC = () => {
       <Routes>
         <Route path="/db-viewer" element={<DatabaseViewerPage />} />
         <Route path="/settings" element={<SettingsPage />} />
+        <Route path="/tasks" element={<TasksPage />} />
         <Route path='/builder' element={<ViewBuilderPage/>}></Route>
         <Route path='/joins' element={<JoinBuilderPage/>}></Route>
         <Route path='/transforms' element={<TransformBuilderPage/>}></Route>

--- a/client/src/app/store.ts
+++ b/client/src/app/store.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import settingsReducer from '../features/settings/settingsSlice';
 import viewBuilderReducer from '../features/viewBuilder/viewBuilderSlice';
+import tasksReducer from '../features/tasks/tasksSlice';
 
 export const store = configureStore({
   reducer: {
     settings: settingsReducer,
     viewBuilder: viewBuilderReducer,
+    tasks: tasksReducer,
   },
 });
 

--- a/client/src/components/NavigationMenu.tsx
+++ b/client/src/components/NavigationMenu.tsx
@@ -23,6 +23,7 @@ const NavigationMenu: React.FC = () => {
   const links = [
     { label: 'Просмотр БД', path: '/db-viewer', enabled: true },
     { label: 'Подключение', path: '/settings', enabled: true },
+    { label: 'Задачи', path: '/tasks', enabled: true },
     { label: 'Таблицы', path: '/builder', enabled: canBuilder },
     { label: 'Джоины', path: '/joins', enabled: canJoins },
     { label: 'Трансформации', path: '/transforms', enabled: canTransforms },

--- a/client/src/features/tasks/TasksPage.tsx
+++ b/client/src/features/tasks/TasksPage.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import { Box, Heading } from '@chakra-ui/react';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from '../../app/store';
+import { useHttp } from '../../hooks/http.hook';
+import TaskTable from './components/TaskTable';
+import PaginationControls from './components/PaginationControls';
+import { setTasks, setPage, setPageSize } from './tasksSlice';
+
+const TasksPage: React.FC = () => {
+  const dispatch = useDispatch<AppDispatch>();
+  const { tasks, page, pageSize } = useSelector((state: RootState) => state.tasks);
+  const { request } = useHttp();
+
+  const fetchTasks = async () => {
+    try {
+      const data = await request('http://localhost:8888/api/get-tasks', 'GET', {
+        page,
+        page_size: pageSize,
+      });
+      dispatch(setTasks(data));
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  useEffect(() => {
+    fetchTasks();
+  }, [page, pageSize]);
+
+  return (
+    <Box p={8} maxW="900px" mx="auto">
+      <Heading mb={4} textAlign="center">
+        Задачи
+      </Heading>
+      <TaskTable tasks={tasks} />
+      <PaginationControls
+        page={page}
+        pageSize={pageSize}
+        onPageChange={(p) => dispatch(setPage(p))}
+        onPageSizeChange={(s) => dispatch(setPageSize(s))}
+      />
+    </Box>
+  );
+};
+
+export default TasksPage;

--- a/client/src/features/tasks/components/PaginationControls.tsx
+++ b/client/src/features/tasks/components/PaginationControls.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { HStack, Button, Select } from '@chakra-ui/react';
+
+interface Props {
+  page: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+}
+
+const PaginationControls: React.FC<Props> = ({
+  page,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}) => (
+  <HStack mt={4} spacing={4} justify="center">
+    <Button onClick={() => onPageChange(page - 1)} isDisabled={page <= 1}>
+      Предыдущая
+    </Button>
+    <Select
+      value={pageSize}
+      onChange={(e) => onPageSizeChange(Number(e.target.value))}
+      width="auto"
+    >
+      {[5, 10, 20, 50].map((size) => (
+        <option key={size} value={size}>
+          {size} на странице
+        </option>
+      ))}
+    </Select>
+    <Button onClick={() => onPageChange(page + 1)}>Следующая</Button>
+  </HStack>
+);
+
+export default PaginationControls;

--- a/client/src/features/tasks/components/TaskTable.tsx
+++ b/client/src/features/tasks/components/TaskTable.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import {
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+  Collapse,
+  Box,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import type { Task } from '../tasksSlice';
+
+interface Props {
+  tasks: Task[];
+}
+
+const TaskTable: React.FC<Props> = ({ tasks }) => {
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const rowBg = useColorModeValue('white', 'gray.700');
+  const expandBg = useColorModeValue('gray.50', 'gray.800');
+
+  return (
+    <Table variant="simple" size="sm">
+      <Thead>
+        <Tr>
+          <Th>ID</Th>
+          <Th>Статус</Th>
+          <Th>Создано</Th>
+        </Tr>
+      </Thead>
+      <Tbody>
+        {tasks.map((task) => (
+          <React.Fragment key={task.id}>
+            <Tr
+              bg={rowBg}
+              _hover={{ bg: useColorModeValue('gray.100', 'gray.600') }}
+              cursor="pointer"
+              onClick={() => setExpanded(expanded === task.id ? null : task.id)}
+            >
+              <Td>{task.id}</Td>
+              <Td>{task.status}</Td>
+              <Td>{new Date(task.create_date).toLocaleString()}</Td>
+            </Tr>
+            <Tr>
+              <Td colSpan={3} p={0} border="none">
+                <Collapse in={expanded === task.id} animateOpacity>
+                  <Box p={4} bg={expandBg}>
+                    {task.comment || 'Нет комментария'}
+                  </Box>
+                </Collapse>
+              </Td>
+            </Tr>
+          </React.Fragment>
+        ))}
+      </Tbody>
+    </Table>
+  );
+};
+
+export default TaskTable;

--- a/client/src/features/tasks/tasksSlice.ts
+++ b/client/src/features/tasks/tasksSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface Task {
+  id: string;
+  status: string;
+  create_date: string;
+  comment?: string | null;
+}
+
+interface TasksState {
+  tasks: Task[];
+  page: number;
+  pageSize: number;
+}
+
+const initialState: TasksState = {
+  tasks: [],
+  page: 1,
+  pageSize: 10,
+};
+
+const tasksSlice = createSlice({
+  name: 'tasks',
+  initialState,
+  reducers: {
+    setTasks(state, action: PayloadAction<Task[]>) {
+      state.tasks = action.payload;
+    },
+    setPage(state, action: PayloadAction<number>) {
+      state.page = action.payload;
+    },
+    setPageSize(state, action: PayloadAction<number>) {
+      state.pageSize = action.payload;
+    },
+  },
+});
+
+export const { setTasks, setPage, setPageSize } = tasksSlice.actions;
+
+export default tasksSlice.reducer;


### PR DESCRIPTION
## Summary
- add tasks slice for Redux
- add TaskTable and PaginationControls components
- create TasksPage with pagination logic
- wire tasks reducer to store
- include tasks route and navigation link

## Testing
- `npm run build`
- `go test ./...` *(fails: TestPrepareAndInsertData)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685d5e378fc48332ac2656abbe11010d