### PR TITLE
Implement dynamic topic notifier in Kafka engine

### DIFF
--- a/analytics-data-center/internal/services/analytics/analytics.go
+++ b/analytics-data-center/internal/services/analytics/analytics.go
@@ -44,6 +44,11 @@ type TaskETL struct {
 	TaskID string
 }
 
+// TopicNotifier allows to send information about new topics to subscribe.
+type TopicNotifier interface {
+	EnqueueTopic(topic string)
+}
+
 type AnalyticsDataCenterService struct {
 	log            *loggerpkg.Logger
 	SchemaProvider storage.SysDB
@@ -56,6 +61,7 @@ type AnalyticsDataCenterService struct {
 	jobQueue       chan TaskETL
 	eventQueue     chan models.CDCEvent
 	SMTPClient     smtpsender.SMTP
+	topicNotifier  TopicNotifier
 }
 
 type TaskService interface {
@@ -93,6 +99,11 @@ func New(
 	go service.etlWorker()
 	go service.eventWorker()
 	return service
+}
+
+// SetTopicNotifier injects notifier implementation used to send topic updates.
+func (a *AnalyticsDataCenterService) SetTopicNotifier(n TopicNotifier) {
+	a.topicNotifier = n
 }
 
 func (a *AnalyticsDataCenterService) StartETLProcess(ctx context.Context, idView int64) (taskID string, err error) {

--- a/analytics-data-center/internal/services/analytics/apiAdapter.go
+++ b/analytics-data-center/internal/services/analytics/apiAdapter.go
@@ -75,6 +75,16 @@ func (a *AnalyticsDataCenterService) UploadSchema(ctx context.Context, schema mo
 		a.log.Error("Ошибка работы с базой данных")
 		return 0, err
 	}
+	if a.topicNotifier != nil {
+		for _, src := range schema.Sources {
+			for _, sch := range src.Schemas {
+				for _, tbl := range sch.Tables {
+					topic := fmt.Sprintf("dbserver_%s.%s.%s", src.Name, sch.Name, tbl.Name)
+					a.topicNotifier.EnqueueTopic(topic)
+				}
+			}
+		}
+	}
 	return id, nil
 
 }

--- a/analytics-data-center/internal/services/tasks/task_test.go
+++ b/analytics-data-center/internal/services/tasks/task_test.go
@@ -57,6 +57,7 @@ func (m *mockSysDB) GetSchems(ctx context.Context, source, schema, table string)
 func (m *mockSysDB) UpdateView(ctx context.Context, view models.View, schemaId int) error { return nil }
 
 func (m *mockSysDB) UploadView(ctx context.Context, view models.View) (int64, error) { return 123, nil }
+func (m *mockSysDB) ListTopics(ctx context.Context) ([]string, error)                { return nil, nil }
 func (m *mockSysDB) GetTasks(ctx context.Context, filters models.TaskFilter) (tasks []models.Task, err error) {
 	return []models.Task{}, nil
 }

--- a/analytics-data-center/internal/storage/interfaces.go
+++ b/analytics-data-center/internal/storage/interfaces.go
@@ -29,6 +29,8 @@ type SchemaProvider interface {
 	GetSchems(ctx context.Context, source string, schema string, table string) ([]int, error)
 	UpdateView(ctx context.Context, view models.View, schemaId int) error
 	UploadView(ctx context.Context, view models.View) (int64, error)
+	// ListTopics returns list of kafka topics required by existing views
+	ListTopics(ctx context.Context) ([]string, error)
 }
 
 type TaskProvider interface {


### PR DESCRIPTION
## Summary
- move topic subscription queue from analytics service into Kafka engine
- inject Kafka engine as topic notifier for analytics service
- fetch required topics from DB inside the engine on startup
- update app initialization to use the new engine

## Testing
- `go build ./...`
- `go test ./...` *(fails: TestPrepareAndInsertData)*

------
https://chatgpt.com/codex/tasks/task_e_685f11d361b483328081ff0532eac5cf