### PR TITLE
Add Load More button to table selector

### DIFF
--- a/client/src/features/viewBuilder/components/TableSelector.tsx
+++ b/client/src/features/viewBuilder/components/TableSelector.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
   Badge,
   Icon,
+  Button,
 } from '@chakra-ui/react';
 import { FaDatabase } from 'react-icons/fa';
 
@@ -21,12 +22,14 @@ interface Props {
   selectedSchemaData: { tables: Table[] };
   selectedTables: string[];
   onToggleTable: (table: string) => void;
+  onLoadMore?: () => void;
 }
 
 const TableSelector: React.FC<Props> = ({
   selectedSchemaData,
   selectedTables,
   onToggleTable,
+  onLoadMore,
 }) => {
   if (!selectedSchemaData) return null;
 
@@ -87,6 +90,11 @@ const TableSelector: React.FC<Props> = ({
           </Fade>
         ))}
       </SimpleGrid>
+      {onLoadMore && (
+        <Box textAlign="center" mt={4}>
+          <Button onClick={onLoadMore}>Загрузить ещё</Button>
+        </Box>
+      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary
- support loading more tables in selector
- expose `onLoadMore` prop in `TableSelector` and render button
- update `ViewBuilderPage` to handle loading more tables using API

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js` and multiple lint errors)*
- `npm run build`
- `go test ./...` *(fails: TestPrepareAndInsertData and others)*

------
https://chatgpt.com/codex/tasks/task_e_6863f3553fd083329c21b9ea0d05253b