### PR TITLE
Fix missing tables across view builder pages

### DIFF
--- a/client/src/features/dbViewer/DatabaseViewerPage.tsx
+++ b/client/src/features/dbViewer/DatabaseViewerPage.tsx
@@ -28,6 +28,7 @@ import DatabaseSelector from '../viewBuilder/components/DatabaseSelector';
 import SchemaSelector from '../viewBuilder/components/SchemaSelector';
 import { setSelectedDb, setSelectedSchema } from '../viewBuilder/viewBuilderSlice';
 import { useHttp } from '../../hooks/http.hook';
+import { appendTables } from '../settings/settingsSlice';
 
 interface TableRow {
   name: string;
@@ -97,6 +98,7 @@ const DatabaseViewerPage: React.FC = () => {
       const newTables = schema?.tables || [];
       if (newTables.length > 0) {
         setTablesState(prev => [...prev, ...newTables]);
+        dispatch(appendTables({ db: selectedDb, schema: selectedSchema, tables: newTables }));
         setPage(nextPage);
       }
     } catch (e) {

--- a/client/src/features/settings/settingsSlice.ts
+++ b/client/src/features/settings/settingsSlice.ts
@@ -30,6 +30,28 @@ const settingsSlice = createSlice({
     setConnectionsMap(state, action: PayloadAction<Record<string, string>>) {
       state.connectionsMap = action.payload;
     },
+    appendTables(
+      state,
+      action: PayloadAction<{
+        db: string;
+        schema: string;
+        tables: any[];
+      }>,
+    ) {
+      const { db, schema, tables } = action.payload;
+      const targetDb = state.dataBaseInfo?.find((d: any) => d.name === db);
+      if (!targetDb) return;
+      const targetSchema = targetDb.schemas?.find((s: any) => s.name === schema);
+      if (!targetSchema) return;
+      const existingNames = new Set(
+        targetSchema.tables.map((t: any) => t.name),
+      );
+      tables.forEach((table) => {
+        if (!existingNames.has(table.name)) {
+          targetSchema.tables.push(table);
+        }
+      });
+    },
   },
 });
 
@@ -38,6 +60,7 @@ export const {
   setSavedConnections,
   setDataForConnection,
   setConnectionsMap,
+  appendTables,
 } = settingsSlice.actions;
 
 export default settingsSlice.reducer;

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -14,6 +14,7 @@ import SchemaSelector from './components/SchemaSelector';
 import TableSelector from './components/TableSelector';
 import ColumnsGrid from './components/ColumnsGrid';
 import { useHttp } from '../../hooks/http.hook';
+import { appendTables } from '../settings/settingsSlice';
 
 const ViewBuilderPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
@@ -66,6 +67,7 @@ const ViewBuilderPage: React.FC = () => {
       const newTables = schema?.tables || [];
       if (newTables.length > 0) {
         setTablesState(prev => [...prev, ...newTables]);
+        dispatch(appendTables({ db: selectedDb, schema: selectedSchema, tables: newTables }));
         setPage(nextPage);
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- keep loaded tables in settings slice to persist across pages
- update DB viewer and view builder pages to store newly loaded tables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864d351efcc83328b3ca30c6bc4d107