### PR TITLE
Enable multi-database view building

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -18,7 +18,7 @@ RUN npm install \
     && npm rebuild esbuild --force
 
 # Билдим
-RUN npm run build
+RUN npm run build -- --mode production
 
 
 # ---------- runtime stage ----------

--- a/analytics-data-center/config/docker.yaml
+++ b/analytics-data-center/config/docker.yaml
@@ -8,9 +8,9 @@ oltp_connections:
   - name: postgres_oltp
     connection_string: "postgresql://postgres:password@postgres:5432/postgres_oltp?sslmode=disable"
     connection_string_kafka: "postgresql://postgres:password@postgres:5432/postgres_oltp?sslmode=disable"
-  - name: postgres_copy
-    connection_string: "postgresql://postgres:password@postgres:5432/postgres_copy?sslmode=disable"
-    connection_string_kafka: "postgresql://postgres:password@postgres:5432/postgres_copy?sslmode=disable"    
+  - name: postgres_oltp_2
+    connection_string: "postgresql://postgres:password@postgres:5432/postgres_oltp_2?sslmode=disable"
+    connection_string_kafka: "postgresql://postgres:password@postgres:5432/postgres_oltp_2?sslmode=disable"
 smtp_setting:
     host: "smtp.example.com"
     port: 587

--- a/analytics-data-center/config/docker.yaml
+++ b/analytics-data-center/config/docker.yaml
@@ -8,6 +8,9 @@ oltp_connections:
   - name: postgres_oltp
     connection_string: "postgresql://postgres:password@postgres:5432/postgres_oltp?sslmode=disable"
     connection_string_kafka: "postgresql://postgres:password@postgres:5432/postgres_oltp?sslmode=disable"
+  - name: postgres_copy
+    connection_string: "postgresql://postgres:password@postgres:5432/postgres_copy?sslmode=disable"
+    connection_string_kafka: "postgresql://postgres:password@postgres:5432/postgres_copy?sslmode=disable"    
 smtp_setting:
     host: "smtp.example.com"
     port: 587

--- a/analytics-data-center/internal/domain/models/data.go
+++ b/analytics-data-center/internal/domain/models/data.go
@@ -4,5 +4,6 @@ type CountInsertData struct {
 	Count         int64  `json:"count,omitempty"`
 	TableName     string `json:"table_name,omitempty"`
 	DataBaseName  string `json:"data_base_name,omitempty"`
+	SchemaName    string `json:"schema_name,omitempty"`
 	TempTableName string `json:"temp_table_name,omitempty"`
 }

--- a/analytics-data-center/internal/domain/models/query.go
+++ b/analytics-data-center/internal/domain/models/query.go
@@ -5,7 +5,9 @@ type Queries struct {
 }
 
 type Query struct {
-	SourceName string
-	TableName  string
-	Query      string
+	SourceName    string
+	SchemaName    string
+	TableName     string
+	BaseTableName string
+	Query         string
 }

--- a/analytics-data-center/internal/domain/models/tempColumn.go
+++ b/analytics-data-center/internal/domain/models/tempColumn.go
@@ -6,6 +6,9 @@ type ViewJoinTable struct {
 
 type TempTable struct {
 	TempTableName string
+	Source        string
+	Schema        string
+	Table         string
 	TempColumns   []TempColumn
 }
 

--- a/analytics-data-center/internal/domain/models/view.go
+++ b/analytics-data-center/internal/domain/models/view.go
@@ -70,17 +70,18 @@ type Reference struct {
 }
 
 type Join struct {
-	Inner *JoinSide `json:"inner"`
+	Inner *JoinCondition `json:"inner"`
 	// TO DO сделать другие джоины потом
-	// Left  JoinSide `json:"left"`
-	// Right JoinSide `json:"right"`
 }
 
-type JoinSide struct {
-	Source       string `json:"source,omitempty"`
-	Schema       string `json:"schema,omitempty"`
-	Table        string `json:"table,omitempty"`
-	MainTable    string `json:"main_table,omitempty"`
-	ColumnFirst  string `json:"column_first,omitempty"`
-	ColumnSecond string `json:"column_second,omitempty"`
+type JoinCondition struct {
+	Left  JoinEndpoint `json:"left"`
+	Right JoinEndpoint `json:"right"`
+}
+
+type JoinEndpoint struct {
+	Source string `json:"source"`
+	Schema string `json:"schema"`
+	Table  string `json:"table"`
+	Column string `json:"column"`
 }

--- a/analytics-data-center/internal/lib/SQLGenerator/createTempTableQueryPostgreSQL.go
+++ b/analytics-data-center/internal/lib/SQLGenerator/createTempTableQueryPostgreSQL.go
@@ -213,8 +213,11 @@ func GenerateQueryCreateTempTablePostgres(
 					return models.Queries{}, nil, err
 				}
 				querySt := &models.Query{
-					TableName: tableName,
-					Query:     b.String(),
+					TableName:     tableName,
+					BaseTableName: tbl.Name,
+					SchemaName:    sch.Name,
+					SourceName:    source.Name,
+					Query:         b.String(),
 				}
 				queryObject = append(queryObject, *querySt)
 			}

--- a/analytics-data-center/internal/lib/SQLGenerator/createViewQueryPostgre.go
+++ b/analytics-data-center/internal/lib/SQLGenerator/createViewQueryPostgre.go
@@ -19,58 +19,149 @@ func CreateViewQueryPostgres(schema models.View, viewJoin models.ViewJoinTable, 
 	}
 
 	aliasMap := make(map[string]string)
-	assignAlias := func(name string, idx int) string {
-		if existing, ok := aliasMap[name]; ok {
-			return existing
+	for idx, tempTable := range viewJoin.TempTables {
+		aliasMap[tempTable.TempTableName] = fmt.Sprintf("t%d", idx+1)
+	}
+
+	resolveTempTable := func(endpoint models.JoinEndpoint) (models.TempTable, string, error) {
+		for _, tempTable := range viewJoin.TempTables {
+			if tempTable.Source == endpoint.Source && tempTable.Schema == endpoint.Schema && tempTable.Table == endpoint.Table {
+				alias, ok := aliasMap[tempTable.TempTableName]
+				if !ok {
+					return models.TempTable{}, "", fmt.Errorf("alias not found for temp table %s", tempTable.TempTableName)
+				}
+				return tempTable, alias, nil
+			}
 		}
-		alias := fmt.Sprintf("t%d", idx+1)
-		aliasMap[name] = alias
-		return alias
+		return models.TempTable{}, "", fmt.Errorf("temp table not found for join endpoint %s.%s.%s", endpoint.Source, endpoint.Schema, endpoint.Table)
+	}
+
+	var joins []struct {
+		leftTable  models.TempTable
+		rightTable models.TempTable
+		leftAlias  string
+		rightAlias string
+		leftCol    string
+		rightCol   string
+	}
+
+	rightKeys := make(map[string]struct{})
+
+	for _, join := range schema.Joins {
+		if join.Inner == nil {
+			continue
+		}
+		left, leftAlias, err := resolveTempTable(join.Inner.Left)
+		if err != nil {
+			return models.Query{}, err
+		}
+		right, rightAlias, err := resolveTempTable(join.Inner.Right)
+		if err != nil {
+			return models.Query{}, err
+		}
+
+		joins = append(joins, struct {
+			leftTable  models.TempTable
+			rightTable models.TempTable
+			leftAlias  string
+			rightAlias string
+			leftCol    string
+			rightCol   string
+		}{
+			leftTable:  left,
+			rightTable: right,
+			leftAlias:  leftAlias,
+			rightAlias: rightAlias,
+			leftCol:    join.Inner.Left.Column,
+			rightCol:   join.Inner.Right.Column,
+		})
+		rightKeys[fmt.Sprintf("%s|%s|%s", right.Source, right.Schema, right.Table)] = struct{}{}
+	}
+
+	if len(joins) == 0 {
+		return models.Query{}, fmt.Errorf("нет настроенных джоинов для формирования вью")
+	}
+
+	var rootTable models.TempTable
+	var rootAlias string
+	for _, j := range joins {
+		key := fmt.Sprintf("%s|%s|%s", j.leftTable.Source, j.leftTable.Schema, j.leftTable.Table)
+		if _, ok := rightKeys[key]; !ok {
+			rootTable = j.leftTable
+			rootAlias = j.leftAlias
+			break
+		}
+	}
+
+	if rootAlias == "" {
+		rootTable = joins[0].leftTable
+		rootAlias = joins[0].leftAlias
+	}
+
+	known := map[string]struct{}{rootTable.TempTableName: {}}
+
+	var joinClauses []string
+	processed := make(map[int]bool)
+
+	for len(processed) < len(joins) {
+		progress := false
+		for idx, j := range joins {
+			if processed[idx] {
+				continue
+			}
+			leftKnown := false
+			rightKnown := false
+			if _, ok := known[j.leftTable.TempTableName]; ok {
+				leftKnown = true
+			}
+			if _, ok := known[j.rightTable.TempTableName]; ok {
+				rightKnown = true
+			}
+
+			if leftKnown && !rightKnown {
+				joinClauses = append(joinClauses, fmt.Sprintf("JOIN %s %s ON %s.%s = %s.%s",
+					pq.QuoteIdentifier(j.rightTable.TempTableName), pq.QuoteIdentifier(j.rightAlias),
+					pq.QuoteIdentifier(j.leftAlias), pq.QuoteIdentifier(j.leftCol),
+					pq.QuoteIdentifier(j.rightAlias), pq.QuoteIdentifier(j.rightCol),
+				))
+				known[j.rightTable.TempTableName] = struct{}{}
+				processed[idx] = true
+				progress = true
+				continue
+			}
+
+			if rightKnown && !leftKnown {
+				joinClauses = append(joinClauses, fmt.Sprintf("JOIN %s %s ON %s.%s = %s.%s",
+					pq.QuoteIdentifier(j.leftTable.TempTableName), pq.QuoteIdentifier(j.leftAlias),
+					pq.QuoteIdentifier(j.rightAlias), pq.QuoteIdentifier(j.rightCol),
+					pq.QuoteIdentifier(j.leftAlias), pq.QuoteIdentifier(j.leftCol),
+				))
+				known[j.leftTable.TempTableName] = struct{}{}
+				processed[idx] = true
+				progress = true
+			}
+		}
+
+		if !progress {
+			return models.Query{}, fmt.Errorf("невозможно связать все джоины: отсутствуют исходные таблицы")
+		}
 	}
 
 	var selectParts []string
-	for idx, tempTable := range viewJoin.TempTables {
-		alias := assignAlias(tempTable.TempTableName, idx)
+	for _, tempTable := range viewJoin.TempTables {
+		if _, ok := known[tempTable.TempTableName]; !ok {
+			continue
+		}
+		alias := aliasMap[tempTable.TempTableName]
 		for _, col := range tempTable.TempColumns {
 			selectParts = append(selectParts, fmt.Sprintf("%s.%s", pq.QuoteIdentifier(alias), pq.QuoteIdentifier(col.ColumnName)))
 		}
 	}
 
 	var b strings.Builder
-	b.WriteString(fmt.Sprintf("CREATE TABLE %s AS SELECT %s", pq.QuoteIdentifier(schema.Name), strings.Join(selectParts, ", ")))
+	b.WriteString(fmt.Sprintf("CREATE TABLE %s AS SELECT %s", pq.QuoteIdentifier(schema.Name), strings.Join(selectParts, ",")))
 
-	mainTableName := ""
-	mainAlias := ""
-	mainTableSet := false
-
-	for _, join := range schema.Joins {
-		if join.Inner != nil && join.Inner.MainTable != "" {
-			mainTableName = fmt.Sprintf("temp_%s_%s_%s", join.Inner.Source, join.Inner.Schema, join.Inner.MainTable)
-			mainAlias = assignAlias(mainTableName, len(aliasMap))
-			mainTableSet = true
-			break
-		}
-	}
-	if !mainTableSet {
-		mainTableName = viewJoin.TempTables[0].TempTableName
-		mainAlias = assignAlias(mainTableName, len(aliasMap))
-	}
-
-	fromClause := fmt.Sprintf(" FROM %s %s", pq.QuoteIdentifier(mainTableName), pq.QuoteIdentifier(mainAlias))
-
-	var joinClauses []string
-	for _, join := range schema.Joins {
-		if join.Inner != nil {
-			joinTable := fmt.Sprintf("temp_%s_%s_%s", join.Inner.Source, join.Inner.Schema, join.Inner.Table)
-			joinAlias := assignAlias(joinTable, len(aliasMap))
-			joinClauses = append(joinClauses, fmt.Sprintf("JOIN %s %s ON %s.%s = %s.%s",
-				pq.QuoteIdentifier(joinTable), pq.QuoteIdentifier(joinAlias),
-				pq.QuoteIdentifier(mainAlias), pq.QuoteIdentifier(join.Inner.ColumnFirst),
-				pq.QuoteIdentifier(joinAlias), pq.QuoteIdentifier(join.Inner.ColumnSecond),
-			))
-		}
-	}
-
+	fromClause := fmt.Sprintf(" FROM %s %s", pq.QuoteIdentifier(rootTable.TempTableName), pq.QuoteIdentifier(rootAlias))
 	joinSQL := strings.Join(joinClauses, " ")
 	if joinSQL != "" {
 		joinSQL = " " + joinSQL

--- a/analytics-data-center/internal/lib/SQLGenerator/getCountQeryPostgreSQL.go
+++ b/analytics-data-center/internal/lib/SQLGenerator/getCountQeryPostgreSQL.go
@@ -29,9 +29,11 @@ func GenerateCountQueries(view models.View, logger *slog.Logger) (queriesCreateT
 					return models.Queries{}, err
 				}
 				queryCount := models.Query{
-					TableName:  tbl.Name,
-					Query:      b.String(),
-					SourceName: source.Name,
+					TableName:     tbl.Name,
+					BaseTableName: tbl.Name,
+					SchemaName:    sch.Name,
+					Query:         b.String(),
+					SourceName:    source.Name,
 				}
 
 				queryObject = append(queryObject, queryCount)

--- a/analytics-data-center/internal/services/analytics/analytics_view_join_test.go
+++ b/analytics-data-center/internal/services/analytics/analytics_view_join_test.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"testing"
 
+	"analyticDataCenter/analytics-data-center/internal/domain/models"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrepareViewJoin(t *testing.T) {
 	dwh := &mockDWH{columns: map[string][]string{"tmp1": {"id", "name"}}}
 	svc := &AnalyticsDataCenterService{log: getTestLogger(), DWHProvider: dwh}
-	res, err := svc.prepareViewJoin(context.Background(), []string{"tmp1"}, "public")
+	res, err := svc.prepareViewJoin(context.Background(), []models.TempTable{{TempTableName: "tmp1"}}, "public")
 
 	require.NoError(t, err)
 	require.Len(t, res.TempTables, 1)

--- a/analytics-data-center/internal/services/analytics/auxiliary.go
+++ b/analytics-data-center/internal/services/analytics/auxiliary.go
@@ -91,6 +91,7 @@ func (a *AnalyticsDataCenterService) getCountInsertData(ctx context.Context, vie
 			TableName:     query.TableName,
 			Count:         count,
 			DataBaseName:  query.SourceName,
+			SchemaName:    query.SchemaName,
 			TempTableName: tempTables[idx],
 		}
 		log.Info("готово", slog.String("TableName", item.TableName))
@@ -109,6 +110,7 @@ func (a *AnalyticsDataCenterService) prepareAndInsertData(ctx context.Context, c
 
 	var (
 		tempTbl  []string
+		tempMeta []models.TempTable
 		wg       sync.WaitGroup
 		hasError bool
 		mu       sync.Mutex
@@ -128,6 +130,12 @@ func (a *AnalyticsDataCenterService) prepareAndInsertData(ctx context.Context, c
 
 		log.Info("запуск вставки и подготовки данных", slog.String("Таблица", tempTableInsert.TableName))
 		tempTbl = append(tempTbl, tempTableInsert.TempTableName)
+		tempMeta = append(tempMeta, models.TempTable{
+			TempTableName: tempTableInsert.TempTableName,
+			Source:        tempTableInsert.DataBaseName,
+			Schema:        tempTableInsert.SchemaName,
+			Table:         tempTableInsert.TableName,
+		})
 
 		oltpStorage, err := a.OLTPFactory.GetOLTPStorage(ctx, tempTableInsert.DataBaseName)
 		if err != nil {
@@ -218,7 +226,7 @@ func (a *AnalyticsDataCenterService) prepareAndInsertData(ctx context.Context, c
 		return false, fmt.Errorf("одна или несколько горутин завершились с ошибкой")
 	}
 
-	viewJoin, err := a.prepareViewJoin(ctx, tempTbl, "public")
+	viewJoin, err := a.prepareViewJoin(ctx, tempMeta, "public")
 	if err != nil {
 		_ = a.DeleteTempTables(ctx, tempTbl)
 		log.Error("Ошибка", slog.String("error", err.Error()))
@@ -254,7 +262,7 @@ func (a *AnalyticsDataCenterService) calculateWorkerCount(totalCount int64) int6
 	}
 }
 
-func (a *AnalyticsDataCenterService) prepareViewJoin(ctx context.Context, tempTbl []string, schemaName string) (viewJoins *models.ViewJoinTable, err error) {
+func (a *AnalyticsDataCenterService) prepareViewJoin(ctx context.Context, tempTbl []models.TempTable, schemaName string) (viewJoins *models.ViewJoinTable, err error) {
 	const op = "analytics.prepareViewJoin"
 	log := a.log.With(
 		slog.String("op", op),
@@ -272,7 +280,7 @@ func (a *AnalyticsDataCenterService) prepareViewJoin(ctx context.Context, tempTb
 			dbName := strings.Trim(u.Path, "/")
 			schemaName = dbName
 		}
-		columnsTempTables, err := a.DWHProvider.GetColumnsTables(ctx, schemaName, tempTable)
+		columnsTempTables, err := a.DWHProvider.GetColumnsTables(ctx, schemaName, tempTable.TempTableName)
 		if err != nil {
 			log.Error("Невозможно получить колонки для временных таблиц", slog.String("error", err.Error()))
 			return nil, err
@@ -285,11 +293,9 @@ func (a *AnalyticsDataCenterService) prepareViewJoin(ctx context.Context, tempTb
 			})
 		}
 
-		tempTables := &models.TempTable{
-			TempTableName: tempTable,
-			TempColumns:   columnsTemp,
-		}
-		tablesTemp = append(tablesTemp, *tempTables)
+		tempTables := tempTable
+		tempTables.TempColumns = columnsTemp
+		tablesTemp = append(tablesTemp, tempTables)
 	}
 
 	viewJoin := &models.ViewJoinTable{

--- a/analytics-data-center/internal/services/analytics/auxiliary.go
+++ b/analytics-data-center/internal/services/analytics/auxiliary.go
@@ -231,7 +231,7 @@ func (a *AnalyticsDataCenterService) prepareAndInsertData(ctx context.Context, c
 		log.Error("Ошибка", slog.String("error", err.Error()))
 		return false, err
 	}
-
+	log.Info("Запрос на мердж", slog.String("Запрос", query.Query))
 	a.DWHProvider.MergeTempTables(ctx, query.Query)
 	_ = a.DeleteTempTables(ctx, tempTbl)
 	return true, nil

--- a/analytics-data-center/internal/services/analytics/createRowAfterListenEvent.go
+++ b/analytics-data-center/internal/services/analytics/createRowAfterListenEvent.go
@@ -264,11 +264,14 @@ func (a *AnalyticsDataCenterService) checkColumnInTables(
 		actualCols := make(map[string]struct{}, len(columns))
 		for _, col := range columns {
 			colLower := strings.ToLower(col)
-			if tables, ok := columnTableMap[colLower]; ok {
-				if _, belongs := tables[targetTable]; !belongs {
-					continue
-				}
+			tables, ok := columnTableMap[colLower]
+			if !ok {
+				continue
 			}
+			if _, belongs := tables[targetTable]; !belongs {
+				continue
+			}
+
 			actualCols[colLower] = struct{}{}
 		}
 

--- a/client/src/components/NavigationMenu.tsx
+++ b/client/src/components/NavigationMenu.tsx
@@ -20,8 +20,13 @@ const NavigationMenu: React.FC = () => {
   const settings = useSelector((state: RootState) => state.settings);
   const builder = useSelector((state: RootState) => state.viewBuilder);
 
+  const selectedColumnsCount = builder.selectedSources.reduce(
+    (acc, source) => acc + source.selectedColumns.length,
+    0,
+  );
+
   const canBuilder = !!settings.dataBaseInfo;
-  const canJoins = builder.selectedColumns.length > 0;
+  const canJoins = selectedColumnsCount > 0;
   const canTransforms = canJoins;
   const canSummary = canTransforms;
 

--- a/client/src/components/NavigationMenu.tsx
+++ b/client/src/components/NavigationMenu.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   IconButton,
   useDisclosure,
@@ -14,15 +14,20 @@ import { HamburgerIcon } from '@chakra-ui/icons';
 import { NavLink } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../app/store';
+import { flattenSelections } from '../features/viewBuilder/viewBuilderSlice';
 
 const NavigationMenu: React.FC = () => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const settings = useSelector((state: RootState) => state.settings);
   const builder = useSelector((state: RootState) => state.viewBuilder);
 
-  const selectedColumnsCount = builder.selectedSources.reduce(
-    (acc, source) => acc + source.selectedColumns.length,
-    0,
+  const selectedColumnsCount = useMemo(
+    () =>
+      flattenSelections(builder).reduce(
+        (acc, source) => acc + source.selectedColumns.length,
+        0,
+      ),
+    [builder],
   );
 
   const canBuilder = !!settings.dataBaseInfo;

--- a/client/src/features/dbViewer/DatabaseViewerPage.tsx
+++ b/client/src/features/dbViewer/DatabaseViewerPage.tsx
@@ -35,7 +35,9 @@ interface TableRow {
 const DatabaseViewerPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
-  const connectionsMap = useSelector((state: RootState) => state.settings.connectionsMap);
+  const selectedConnections = useSelector(
+    (state: RootState) => state.settings.selectedConnections,
+  );
   const { currentDb, currentSchema } = useSelector((state: RootState) => state.viewBuilder);
   const { request } = useHttp();
   const url = '/api';
@@ -61,7 +63,9 @@ const DatabaseViewerPage: React.FC = () => {
     const nextPage = page + 1;
     try {
       const body = {
-        connection_strings: [{ connection_string: connectionsMap }],
+        connection_strings: selectedConnections.map((connection_string) => ({
+          connection_string,
+        })),
         page: nextPage,
         page_size: pageSize,
       };

--- a/client/src/features/dbViewer/DatabaseViewerPage.tsx
+++ b/client/src/features/dbViewer/DatabaseViewerPage.tsx
@@ -34,6 +34,7 @@ interface TableRow {
 const DatabaseViewerPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
+  const savedConnections = useSelector((state: RootState) => state.settings.savedConnections);
   const selectedConnections = useSelector(
     (state: RootState) => state.settings.selectedConnections,
   );
@@ -81,9 +82,15 @@ const DatabaseViewerPage: React.FC = () => {
   const loadMore = async () => {
     const nextPage = page + 1;
     try {
+      const connectionStrings = selectedConnections
+        .map((key) => ({ key, value: savedConnections[key] }))
+        .filter((item): item is { key: string; value: string } => Boolean(item.value));
+
       const body = {
-        connection_strings: selectedConnections.map((connection_string) => ({
-          connection_string,
+        connection_strings: connectionStrings.map(({ key, value }) => ({
+          connection_string: {
+            [key]: value,
+          },
         })),
         page: nextPage,
         page_size: pageSize,

--- a/client/src/features/dbViewer/DatabaseViewerPage.tsx
+++ b/client/src/features/dbViewer/DatabaseViewerPage.tsx
@@ -23,7 +23,7 @@ import { useSelector, useDispatch } from 'react-redux';
 import type { RootState, AppDispatch } from '../../app/store';
 import DatabaseSelector from '../viewBuilder/components/DatabaseSelector';
 import SchemaSelector from '../viewBuilder/components/SchemaSelector';
-import { setSelectedDb, setSelectedSchema } from '../viewBuilder/viewBuilderSlice';
+import { setCurrentDb, setCurrentSchema } from '../viewBuilder/viewBuilderSlice';
 import { useHttp } from '../../hooks/http.hook';
 import { appendTables } from '../settings/settingsSlice';
 
@@ -36,12 +36,12 @@ const DatabaseViewerPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
   const connectionsMap = useSelector((state: RootState) => state.settings.connectionsMap);
-  const { selectedDb, selectedSchema } = useSelector((state: RootState) => state.viewBuilder);
+  const { currentDb, currentSchema } = useSelector((state: RootState) => state.viewBuilder);
   const { request } = useHttp();
   const url = '/api';
 
-  const selectedDatabase = data?.find((db: any) => db.name === selectedDb);
-  const selectedSchemaData = selectedDatabase?.schemas?.find((s: any) => s.name === selectedSchema);
+  const selectedDatabase = data?.find((db: any) => db.name === currentDb);
+  const selectedSchemaData = selectedDatabase?.schemas?.find((s: any) => s.name === currentSchema);
 
   const [tablesState, setTablesState] = useState<TableRow[]>(selectedSchemaData?.tables || []);
   const [page, setPage] = useState(1);
@@ -66,12 +66,12 @@ const DatabaseViewerPage: React.FC = () => {
         page_size: pageSize,
       };
       const dbInfo = await request(`${url}/get-db`, 'POST', body);
-      const db = dbInfo.find((d: any) => d.name === selectedDb);
-      const schema = db?.schemas?.find((s: any) => s.name === selectedSchema);
+      const db = dbInfo.find((d: any) => d.name === currentDb);
+      const schema = db?.schemas?.find((s: any) => s.name === currentSchema);
       const newTables = schema?.tables || [];
       if (newTables.length > 0) {
         setTablesState((prev) => [...prev, ...newTables]);
-        dispatch(appendTables({ db: selectedDb, schema: selectedSchema, tables: newTables }));
+        dispatch(appendTables({ db: currentDb, schema: currentSchema, tables: newTables }));
         setPage(nextPage);
       }
     } catch (e) {
@@ -119,29 +119,29 @@ const DatabaseViewerPage: React.FC = () => {
           <SimpleGrid columns={{ base: 1, md: 2 }} spacing={3} alignItems="center">
             <DatabaseSelector
               data={data}
-              selectedDb={selectedDb}
-              onChange={(db) => dispatch(setSelectedDb(db))}
+              selectedDb={currentDb}
+              onChange={(db) => dispatch(setCurrentDb(db))}
             />
-            {selectedDb && selectedDatabase && (
+            {currentDb && selectedDatabase && (
               <SchemaSelector
                 selectedDatabase={selectedDatabase}
-                selectedSchema={selectedSchema}
-                onChange={(schema) => dispatch(setSelectedSchema(schema))}
+                selectedSchema={currentSchema}
+                onChange={(schema) => dispatch(setCurrentSchema(schema))}
               />
             )}
           </SimpleGrid>
         </CardBody>
       </Card>
 
-      {selectedSchema && (
+      {currentSchema && (
         <Stack spacing={4}>
           <Card variant="surface">
             <CardBody>
               <HStack justify="space-between" mb={3} align="center">
                 <HStack>
                   <Icon as={FiDatabase} />
-                  <Text fontWeight="bold">{selectedDb}</Text>
-                  <Badge>{selectedSchema}</Badge>
+                  <Text fontWeight="bold">{currentDb}</Text>
+                  <Badge>{currentSchema}</Badge>
                 </HStack>
                 <Button
                   leftIcon={<FiRefreshCw />}

--- a/client/src/features/settings/SettingsPage.tsx
+++ b/client/src/features/settings/SettingsPage.tsx
@@ -14,7 +14,12 @@ import {
 } from '@chakra-ui/react';
 // import { ChevronDownIcon } from '@chakra-ui/icons';
 import {useDispatch} from 'react-redux';
-import {setConnectionString, setDataForConnection, setSavedConnections, setConnectionsMap} from './settingsSlice';
+import {
+    setConnectionString,
+    setDataForConnection,
+    setSavedConnections,
+    setSelectedConnections,
+} from './settingsSlice';
 import {useNavigate} from 'react-router-dom';
 import {useHttp} from '../../hooks/http.hook';
 
@@ -24,24 +29,20 @@ const SettingsPage : React.FC = () => {
     const {request} = useHttp();
 
     const [selectedConnections,
-        setSelectedConnections] = useState < string[] > ([]);
+        setSelectedConnectionsState] = useState < string[] > ([]);
     const [availableConnections,
         setAvailableConnections] = useState < string[] > ([]);
     const [loading,
         setLoading] = useState(false);
 
     const url = '/api';
-const [rawData, setRawData] = useState<Record<string, string>>({});
-
     const fetchConnections = async() => {
         setLoading(true);
         try {
             const rawData = await request(`${url}/get-connections`);
-            setRawData(rawData);
             const data : string[] = Object.values(rawData);
             setAvailableConnections(data);
             dispatch(setSavedConnections(data));
-            dispatch(setConnectionsMap(rawData));
         } catch (e) {
             console.error('Ошибка при получении списка подключений:', e);
         } finally {
@@ -50,7 +51,7 @@ const [rawData, setRawData] = useState<Record<string, string>>({});
     };
 
     const handleToggle = (conn : string) => {
-        setSelectedConnections((prev) => prev.includes(conn)
+        setSelectedConnectionsState((prev) => prev.includes(conn)
             ? prev.filter((c) => c !== conn)
             : [
                 ...prev,
@@ -64,10 +65,13 @@ const [rawData, setRawData] = useState<Record<string, string>>({});
         
         const conn = selectedConnections[0];
         dispatch(setConnectionString(conn));
+        dispatch(setSelectedConnections(selectedConnections));
 
         try {
         const body = {
-            connection_strings: [{ connection_string: rawData }],
+            connection_strings: selectedConnections.map((connection_string) => ({
+                connection_string,
+            })),
             page: 1,
             page_size: 20,
         };

--- a/client/src/features/settings/settingsSlice.ts
+++ b/client/src/features/settings/settingsSlice.ts
@@ -2,14 +2,14 @@ import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
 interface SettingsState {
   connectionString: string;
-  savedConnections: string[];
+  savedConnections: Record<string, string>;
   dataBaseInfo: any;
   selectedConnections: string[];
 }
 
 const initialState: SettingsState = {
   connectionString: '',
-  savedConnections: [],
+  savedConnections: {},
   dataBaseInfo: null,
   selectedConnections: [],
 };
@@ -21,7 +21,7 @@ const settingsSlice = createSlice({
     setConnectionString(state, action: PayloadAction<string>) {
       state.connectionString = action.payload;
     },
-    setSavedConnections(state, action: PayloadAction<string[]>) {
+    setSavedConnections(state, action: PayloadAction<Record<string, string>>) {
       state.savedConnections = action.payload;
     },
     setDataForConnection(state, action: PayloadAction<any>) {

--- a/client/src/features/settings/settingsSlice.ts
+++ b/client/src/features/settings/settingsSlice.ts
@@ -4,14 +4,14 @@ interface SettingsState {
   connectionString: string;
   savedConnections: string[];
   dataBaseInfo: any;
-  connectionsMap: Record<string, string>;
+  selectedConnections: string[];
 }
 
 const initialState: SettingsState = {
   connectionString: '',
   savedConnections: [],
   dataBaseInfo: null,
-  connectionsMap: {},
+  selectedConnections: [],
 };
 
 const settingsSlice = createSlice({
@@ -27,8 +27,8 @@ const settingsSlice = createSlice({
     setDataForConnection(state, action: PayloadAction<any>) {
       state.dataBaseInfo = action.payload;
     },
-    setConnectionsMap(state, action: PayloadAction<Record<string, string>>) {
-      state.connectionsMap = action.payload;
+    setSelectedConnections(state, action: PayloadAction<string[]>) {
+      state.selectedConnections = action.payload;
     },
     appendTables(
       state,
@@ -59,7 +59,7 @@ export const {
   setConnectionString,
   setSavedConnections,
   setDataForConnection,
-  setConnectionsMap,
+  setSelectedConnections,
   appendTables,
 } = settingsSlice.actions;
 

--- a/client/src/features/summary/SummaryPage.tsx
+++ b/client/src/features/summary/SummaryPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Box, Heading, Text, VStack, Divider, Badge, HStack } from '@chakra-ui/react';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../../app/store';
@@ -6,14 +6,16 @@ import ViewPreview from './components/ViewPreview';
 import SummaryActions from './components/SummaryActions';
 import FlowLayout from '../../components/FlowLayout';
 import { builderSteps } from '../viewBuilder/flowSteps';
+import { flattenSelections } from '../viewBuilder/viewBuilderSlice';
 
 const SummaryPage: React.FC = () => {
   const settings = useSelector((state: RootState) => state.settings);
   const builder = useSelector((state: RootState) => state.viewBuilder);
 
   const data = settings.dataBaseInfo;
+  const selectedSources = useMemo(() => flattenSelections(builder), [builder]);
 
-  const sources = builder.selectedSources
+  const sources = selectedSources
     .map((source) => {
       const selectedDatabase = data?.find((db: any) => db.name === source.db);
       const selectedSchemaData = selectedDatabase?.schemas?.find(
@@ -94,7 +96,7 @@ const SummaryPage: React.FC = () => {
             предупреждениях и безопасности.
           </Text>
           <HStack spacing={3} mt={3} flexWrap="wrap">
-            {builder.selectedSources.map((source) => (
+            {selectedSources.map((source) => (
               <Badge key={`${source.db}.${source.schema}`} colorScheme="cyan">
                 {source.db}.{source.schema}
               </Badge>

--- a/client/src/features/viewBuilder/JoinBuilderPage.tsx
+++ b/client/src/features/viewBuilder/JoinBuilderPage.tsx
@@ -87,12 +87,18 @@ const JoinBuilderPage: React.FC = () => {
 
     const join = {
       inner: {
-        table: joinTableName,
-        schema: joinSchema,
-        source: joinDb,
-        main_table: mainTableName,
-        column_first: mainColumn,
-        column_second: joinColumn,
+        left: {
+          table: mainTableName,
+          schema: mainSchema,
+          source: mainDb,
+          column: mainColumn,
+        },
+        right: {
+          table: joinTableName,
+          schema: joinSchema,
+          source: joinDb,
+          column: joinColumn,
+        },
       },
     };
     dispatch(addJoin(join));
@@ -281,7 +287,7 @@ const JoinBuilderPage: React.FC = () => {
             ) : (
               <SimpleGrid columns={{ base: 1, md: 2 }} spacing={3}>
                 {joins.map((j: JoinRule, idx: number) => (
-                  <Card key={`${j.inner.table}-${idx}`} variant="glass">
+                  <Card key={`${j.inner.left.table}-${j.inner.right.table}-${idx}`} variant="glass">
                     <CardBody>
                       <HStack justify="space-between" mb={2}>
                         <HStack>
@@ -298,14 +304,14 @@ const JoinBuilderPage: React.FC = () => {
                       </HStack>
                       <VStack align="stretch" spacing={2} fontSize="sm">
                         <HStack>
-                          <Tag colorScheme="cyan">{`${j.inner.source}.${j.inner.schema}.${j.inner.main_table}`}</Tag>
+                          <Tag colorScheme="cyan">{`${j.inner.left.source}.${j.inner.left.schema}.${j.inner.left.table}`}</Tag>
                           <Icon as={FiKey} />
-                          <Text>{j.inner.column_first}</Text>
+                          <Text>{j.inner.left.column}</Text>
                         </HStack>
                         <HStack>
-                          <Tag colorScheme="purple">{`${j.inner.source}.${j.inner.schema}.${j.inner.table}`}</Tag>
+                          <Tag colorScheme="purple">{`${j.inner.right.source}.${j.inner.right.schema}.${j.inner.right.table}`}</Tag>
                           <Icon as={FiKey} />
-                          <Text>{j.inner.column_second}</Text>
+                          <Text>{j.inner.right.column}</Text>
                         </HStack>
                         <Tooltip label="Мы блокируем cartesian join, если ключ не указан" placement="top">
                           <Text color="text.muted">Ключи обязательно должны быть выбраны.</Text>

--- a/client/src/features/viewBuilder/JoinBuilderPage.tsx
+++ b/client/src/features/viewBuilder/JoinBuilderPage.tsx
@@ -23,6 +23,7 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../../app/store';
+import type { JoinRule } from './viewBuilderSlice';
 import { addJoin, removeJoin, setViewName, flattenSelections } from './viewBuilderSlice';
 import { DeleteIcon } from '@chakra-ui/icons';
 import { FiKey, FiLink2 } from 'react-icons/fi';
@@ -85,18 +86,13 @@ const JoinBuilderPage: React.FC = () => {
     const [joinDb, joinSchema, joinTableName] = joinTable.split('.');
 
     const join = {
-      type: 'INNER' as const,
-      left: {
-        db: mainDb,
-        schema: mainSchema,
-        table: mainTableName,
-        column: mainColumn,
-      },
-      right: {
-        db: joinDb,
-        schema: joinSchema,
+      inner: {
         table: joinTableName,
-        column: joinColumn,
+        schema: joinSchema,
+        source: joinDb,
+        main_table: mainTableName,
+        column_first: mainColumn,
+        column_second: joinColumn,
       },
     };
     dispatch(addJoin(join));
@@ -284,8 +280,8 @@ const JoinBuilderPage: React.FC = () => {
               <Text color="text.muted">Добавь хотя бы одно правило, если используешь более одной таблицы.</Text>
             ) : (
               <SimpleGrid columns={{ base: 1, md: 2 }} spacing={3}>
-                {joins.map((j: any, idx: number) => (
-                  <Card key={`${j.left.table}-${idx}`} variant="glass">
+                {joins.map((j: JoinRule, idx: number) => (
+                  <Card key={`${j.inner.table}-${idx}`} variant="glass">
                     <CardBody>
                       <HStack justify="space-between" mb={2}>
                         <HStack>
@@ -302,14 +298,14 @@ const JoinBuilderPage: React.FC = () => {
                       </HStack>
                       <VStack align="stretch" spacing={2} fontSize="sm">
                         <HStack>
-                          <Tag colorScheme="cyan">{`${j.left.db}.${j.left.schema}.${j.left.table}`}</Tag>
+                          <Tag colorScheme="cyan">{`${j.inner.source}.${j.inner.schema}.${j.inner.main_table}`}</Tag>
                           <Icon as={FiKey} />
-                          <Text>{j.left.column}</Text>
+                          <Text>{j.inner.column_first}</Text>
                         </HStack>
                         <HStack>
-                          <Tag colorScheme="purple">{`${j.right.db}.${j.right.schema}.${j.right.table}`}</Tag>
+                          <Tag colorScheme="purple">{`${j.inner.source}.${j.inner.schema}.${j.inner.table}`}</Tag>
                           <Icon as={FiKey} />
-                          <Text>{j.right.column}</Text>
+                          <Text>{j.inner.column_second}</Text>
                         </HStack>
                         <Tooltip label="Мы блокируем cartesian join, если ключ не указан" placement="top">
                           <Text color="text.muted">Ключи обязательно должны быть выбраны.</Text>

--- a/client/src/features/viewBuilder/JoinBuilderPage.tsx
+++ b/client/src/features/viewBuilder/JoinBuilderPage.tsx
@@ -80,12 +80,11 @@ const JoinBuilderPage: React.FC = () => {
     const mainMeta = tableMetaMap.get(mainTable);
     const joinMeta = tableMetaMap.get(joinTable);
     if (!mainMeta || !joinMeta) return;
-    if (mainMeta.db !== joinMeta.db || mainMeta.schema !== joinMeta.schema) return;
 
     const join = {
       inner: {
-        source: mainMeta.db,
-        schema: mainMeta.schema,
+        source: joinMeta.db,
+        schema: joinMeta.schema,
         table: joinMeta.table,
         main_table: mainMeta.table,
         column_first: mainColumn,

--- a/client/src/features/viewBuilder/TransformBuilderPage.tsx
+++ b/client/src/features/viewBuilder/TransformBuilderPage.tsx
@@ -36,30 +36,37 @@ const TransformBuilderPage: React.FC = () => {
   const navigate = useNavigate();
 
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
-  const {
-    selectedDb,
-    selectedSchema,
-    selectedTables,
-    selectedColumns,
-    transformations,
-  } = useSelector((state: RootState) => state.viewBuilder);
+  const { selectedSources, transformations } = useSelector(
+    (state: RootState) => state.viewBuilder,
+  );
 
-  const selectedDatabase = data?.find((db: any) => db.name === selectedDb);
-  const selectedSchemaData = selectedDatabase?.schemas?.find((s: any) => s.name === selectedSchema);
+  const [local, setLocal] = useState<Record<string, LocalTransformState>>({});
 
-  const initial: Record<string, LocalTransformState> = {};
-  selectedColumns.forEach((c) => {
-    const key = `${c.table}.${c.column}`;
-    const existing = transformations[key];
-    initial[key] = {
-      type: existing?.type || '',
-      output: existing?.output_column || c.alias || '',
-      mapping: existing?.mapping?.mapping ? JSON.stringify(existing.mapping.mapping, null, 2) : '',
-      mappingJson: existing?.mapping?.mapping_json ? JSON.stringify(existing.mapping.mapping_json, null, 2) : '',
-    };
-  });
+  const buildKey = (payload: { db: string; schema: string; table: string; column: string }) =>
+    `${payload.db}.${payload.schema}.${payload.table}.${payload.column}`;
 
-  const [local, setLocal] = useState<Record<string, LocalTransformState>>(initial);
+  const selectedColumns = selectedSources.flatMap((source) => source.selectedColumns);
+
+  const rebuildLocal = () => {
+    const next: Record<string, LocalTransformState> = {};
+    selectedColumns.forEach((c) => {
+      const key = buildKey(c);
+      const existing = transformations[key];
+      next[key] = {
+        type: existing?.type || '',
+        output: existing?.output_column || c.alias || '',
+        mapping: existing?.mapping?.mapping ? JSON.stringify(existing.mapping.mapping, null, 2) : '',
+        mappingJson: existing?.mapping?.mapping_json
+          ? JSON.stringify(existing.mapping.mapping_json, null, 2)
+          : '',
+      };
+    });
+    setLocal(next);
+  };
+
+  React.useEffect(() => {
+    rebuildLocal();
+  }, [selectedColumns, transformations]);
 
   const updateField = (key: string, field: keyof LocalTransformState, value: string) => {
     setLocal((prev) => ({ ...prev, [key]: { ...prev[key], [field]: value } }));
@@ -67,12 +74,14 @@ const TransformBuilderPage: React.FC = () => {
 
   const handleSave = async () => {
     Object.entries(local).forEach(([key, val]) => {
-      const [table, column] = key.split('.');
+      const [db, schema, table, column] = key.split('.');
       const selectedCol = selectedColumns.find(
-        (c) => c.table === table && c.column === column,
+        (c) => c.table === table && c.column === column && c.db === db && c.schema === schema,
       );
       if (!val.type) {
-        dispatch(setTransformation({ table, column, transform: null }));
+        dispatch(
+          setTransformation({ db, schema, table, column, transform: null }),
+        );
         return;
       }
       let mapping: any = {};
@@ -92,21 +101,26 @@ const TransformBuilderPage: React.FC = () => {
         output_column: val.output || selectedCol?.alias || column,
         mapping,
       };
-      dispatch(setTransformation({ table, column, transform }));
+      dispatch(setTransformation({ db, schema, table, column, transform }));
     });
 
     navigate('/summary');
   };
 
-  const renderColumn = (table: string, column: any) => {
-    const key = `${table}.${column.name}`;
+  const renderColumn = (db: string, schema: string, table: string, column: any) => {
+    const key = `${db}.${schema}.${table}.${column.name}`;
     if (!local[key]) return null;
     const val = local[key];
     const otherColumns = selectedColumns.filter(
-      (c) => c.table !== table || c.column !== column.name,
+      (c) =>
+        c.table !== table || c.column !== column.name || c.db !== db || c.schema !== schema,
     );
     const selectedCol = selectedColumns.find(
-      (c) => c.table === table && c.column === column.name,
+      (c) =>
+        c.table === table &&
+        c.column === column.name &&
+        c.db === db &&
+        c.schema === schema,
     );
     return (
       <Box
@@ -125,6 +139,8 @@ const TransformBuilderPage: React.FC = () => {
           onChange={(e) =>
             dispatch(
               setViewKey({
+                db,
+                schema,
                 table,
                 column: column.name,
                 viewKey: e.target.value,
@@ -145,6 +161,8 @@ const TransformBuilderPage: React.FC = () => {
             onChange={(e) =>
               dispatch(
                 setUpdateKey({
+                  db,
+                  schema,
                   table,
                   column: column.name,
                   isUpdateKey: e.target.checked,
@@ -202,20 +220,35 @@ const TransformBuilderPage: React.FC = () => {
           Перед применением проверь конфликты алиасов и обновляемые поля.
         </Alert>
 
-        {selectedTables.map((tableName) => {
-          const tableData = selectedSchemaData?.tables.find((t: any) => t.name === tableName);
-          return (
-            <Box key={tableName}>
-              <HStack justify="space-between" mb={2}>
-                <Text fontSize="lg" fontWeight="bold">{tableName}</Text>
-                <Tag colorScheme="cyan">{tableData?.columns?.length || 0} колонок</Tag>
-              </HStack>
-              <Divider mb={2} />
-              {tableData?.columns
-                .filter((col: any) => selectedColumns.some((c) => c.table === tableName && c.column === col.name))
-                .map((col: any) => renderColumn(tableName, col))}
-            </Box>
-          );
+        {selectedSources.map((source) => {
+          const dbData = data?.find((db: any) => db.name === source.db);
+          const schemaData = dbData?.schemas?.find((s: any) => s.name === source.schema);
+          return source.selectedTables.map((tableName) => {
+            const tableData = schemaData?.tables.find((t: any) => t.name === tableName);
+            const key = `${source.db}.${source.schema}.${tableName}`;
+            return (
+              <Box key={key}>
+                <HStack justify="space-between" mb={2}>
+                  <Text fontSize="lg" fontWeight="bold">
+                    {source.db}.{source.schema}.{tableName}
+                  </Text>
+                  <Tag colorScheme="cyan">{tableData?.columns?.length || 0} колонок</Tag>
+                </HStack>
+                <Divider mb={2} />
+                {tableData?.columns
+                  .filter((col: any) =>
+                    selectedColumns.some(
+                      (c) =>
+                        c.table === tableName &&
+                        c.column === col.name &&
+                        c.db === source.db &&
+                        c.schema === source.schema,
+                    ),
+                  )
+                  .map((col: any) => renderColumn(source.db, source.schema, tableName, col))}
+              </Box>
+            );
+          });
         })}
       </VStack>
     </FlowLayout>

--- a/client/src/features/viewBuilder/TransformBuilderPage.tsx
+++ b/client/src/features/viewBuilder/TransformBuilderPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import {
   Box,
   Heading,
@@ -19,7 +19,7 @@ import {
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../../app/store';
-import { setTransformation, setUpdateKey, setViewKey } from './viewBuilderSlice';
+import { setTransformation, setUpdateKey, setViewKey, flattenSelections } from './viewBuilderSlice';
 import { InfoIcon } from '@chakra-ui/icons';
 import FlowLayout from '../../components/FlowLayout';
 import { builderSteps } from './flowSteps';
@@ -36,9 +36,9 @@ const TransformBuilderPage: React.FC = () => {
   const navigate = useNavigate();
 
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
-  const { selectedSources, transformations } = useSelector(
-    (state: RootState) => state.viewBuilder,
-  );
+  const builder = useSelector((state: RootState) => state.viewBuilder);
+  const selectedSources = useMemo(() => flattenSelections(builder), [builder]);
+  const { transformations } = builder;
 
   const [local, setLocal] = useState<Record<string, LocalTransformState>>({});
 

--- a/client/src/features/viewBuilder/TransformBuilderPage.tsx
+++ b/client/src/features/viewBuilder/TransformBuilderPage.tsx
@@ -45,7 +45,10 @@ const TransformBuilderPage: React.FC = () => {
   const buildKey = (payload: { db: string; schema: string; table: string; column: string }) =>
     `${payload.db}.${payload.schema}.${payload.table}.${payload.column}`;
 
-  const selectedColumns = selectedSources.flatMap((source) => source.selectedColumns);
+  const selectedColumns = useMemo(
+    () => selectedSources.flatMap((source) => source.selectedColumns),
+    [selectedSources],
+  );
 
   const rebuildLocal = () => {
     const next: Record<string, LocalTransformState> = {};

--- a/client/src/features/viewBuilder/TransformBuilderPage.tsx
+++ b/client/src/features/viewBuilder/TransformBuilderPage.tsx
@@ -107,6 +107,8 @@ const TransformBuilderPage: React.FC = () => {
     navigate('/summary');
   };
 
+  const cardBackground = useColorModeValue('gray.50', 'gray.700');
+
   const renderColumn = (db: string, schema: string, table: string, column: any) => {
     const key = `${db}.${schema}.${table}.${column.name}`;
     if (!local[key]) return null;
@@ -129,7 +131,7 @@ const TransformBuilderPage: React.FC = () => {
         borderWidth="1px"
         borderRadius="md"
         mb={4}
-        background={useColorModeValue('gray.50', 'gray.700')}
+        background={cardBackground}
       >
         <Text mb={2} fontWeight="bold">{table}.{column.name}</Text>
         <Select

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -1,15 +1,18 @@
-import React, { useState, useEffect } from 'react';
-import { Box, Heading, VStack, Text, HStack, Badge, Divider } from '@chakra-ui/react';
+import React from 'react';
+import { Box, Heading, VStack, Text, HStack, Badge, Divider, Stack } from '@chakra-ui/react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { RootState, AppDispatch } from '../../app/store';
 import {
-  setCurrentDb,
-  setCurrentSchema,
+  setSelectedDatabases,
+  setSchemasForDb,
   toggleTable,
   toggleColumn,
   setTableColumns,
   setColumnAlias,
+  flattenSelections,
+  setTableStatus,
+  setSchemaStatus,
 } from './viewBuilderSlice';
 import DatabaseSelector from './components/DatabaseSelector';
 import SchemaSelector from './components/SchemaSelector';
@@ -20,38 +23,55 @@ import { appendTables } from '../settings/settingsSlice';
 import FlowLayout from '../../components/FlowLayout';
 import { builderSteps } from './flowSteps';
 
+interface DatabaseInfo {
+  name: string;
+  schemas?: SchemaInfo[];
+}
+
+interface SchemaInfo {
+  name: string;
+  tables?: TableInfo[];
+}
+
+interface TableInfo {
+  name: string;
+  columns?: any[];
+  rows?: number;
+}
+
 const ViewBuilderPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
-  const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
+  const data = useSelector((state: RootState) => state.settings.dataBaseInfo) as DatabaseInfo[];
   const selectedConnections = useSelector(
     (state: RootState) => state.settings.selectedConnections,
   );
-  const { currentDb, currentSchema, selectedSources } = useSelector(
-    (state: RootState) => state.viewBuilder,
-  );
+  const builder = useSelector((state: RootState) => state.viewBuilder);
+  const selectedSources = React.useMemo(() => flattenSelections(builder), [builder]);
+
+  const { selectedDatabases, selectedSchemasByDb, selectionsByDbSchema } = builder;
+
   const { request } = useHttp();
   const url = '/api';
-
-  const [tablesState, setTablesState] = useState<any[]>([]);
-  const [page, setPage] = useState(1);
   const pageSize = 20;
 
-
-  const handleToggleTable = (table: string) => {
-    if (!currentDb || !currentSchema) return;
-    dispatch(toggleTable({ db: currentDb, schema: currentSchema, table }));
+  const handleDatabaseChange = (dbs: string[]) => {
+    dispatch(setSelectedDatabases(dbs));
   };
 
-  const handleToggleColumn = (
-    table: string,
-    column: any,
-  ) => {
-    if (!currentDb || !currentSchema) return;
+  const handleSchemaChange = (db: string, schemas: string[]) => {
+    dispatch(setSchemasForDb({ db, schemas }));
+  };
+
+  const handleToggleTable = (db: string, schema: string, table: string) => {
+    dispatch(toggleTable({ db, schema, table }));
+  };
+
+  const handleToggleColumn = (db: string, schema: string, table: string, column: any) => {
     dispatch(
       toggleColumn({
-        db: currentDb,
-        schema: currentSchema,
+        db,
+        schema,
         table,
         column: column.name,
         isPrimaryKey: column.is_primary_key || column.is_pk,
@@ -60,12 +80,11 @@ const ViewBuilderPage: React.FC = () => {
     );
   };
 
-  const handleSetTableColumns = (table: string, columns: any[]) => {
-    if (!currentDb || !currentSchema) return;
+  const handleSetTableColumns = (db: string, schema: string, table: string, columns: any[]) => {
     dispatch(
       setTableColumns({
-        db: currentDb,
-        schema: currentSchema,
+        db,
+        schema,
         table,
         columns: columns.map((col) => ({
           name: col.name,
@@ -76,31 +95,25 @@ const ViewBuilderPage: React.FC = () => {
     );
   };
 
-  const handleAliasChange = (table: string, column: string, alias: string) => {
-    if (!currentDb || !currentSchema) return;
-    dispatch(setColumnAlias({ db: currentDb, schema: currentSchema, table, column, alias }));
+  const handleAliasChange = (
+    db: string,
+    schema: string,
+    table: string,
+    column: string,
+    alias: string,
+  ) => {
+    dispatch(setColumnAlias({ db, schema, table, column, alias }));
   };
 
-  const selectedDatabase = data?.find((db: any) => db.name === currentDb);
-  const selectedSchemaData = selectedDatabase?.schemas?.find((schema: any) => schema.name === currentSchema);
-
-  const currentSelection = selectedSources.find(
-    (source) => source.db === currentDb && source.schema === currentSchema,
-  );
-  const selectedTables = currentSelection?.selectedTables ?? [];
-  const selectedColumns = currentSelection?.selectedColumns ?? [];
-
-  useEffect(() => {
-    setTablesState(selectedSchemaData?.tables || []);
-    setPage(1);
-  }, [selectedSchemaData]);
-
-  const schemaDataWithTables = selectedSchemaData
-    ? { ...selectedSchemaData, tables: tablesState }
-    : undefined;
-
-  const loadMore = async () => {
-    const nextPage = page + 1;
+  const loadMore = async (db: string, schema: string) => {
+    const status = builder.tableStatusByDbSchema[db]?.[schema] || {
+      page: 1,
+      hasMore: true,
+      loading: false,
+    };
+    if (status.loading || !status.hasMore) return;
+    const nextPage = status.page + 1;
+    dispatch(setTableStatus({ db, schema, status: { loading: true } }));
     try {
       const body = {
         connection_strings: selectedConnections.map((connection_string) => ({
@@ -110,18 +123,63 @@ const ViewBuilderPage: React.FC = () => {
         page_size: pageSize,
       };
       const dbInfo = await request(`${url}/get-db`, 'POST', body);
-      const db = dbInfo.find((d: any) => d.name === currentDb);
-      const schema = db?.schemas?.find((s: any) => s.name === currentSchema);
-      const newTables = schema?.tables || [];
+      const responseDb = dbInfo.find((d: DatabaseInfo) => d.name === db);
+      const responseSchema = responseDb?.schemas?.find((s: SchemaInfo) => s.name === schema);
+      const newTables = responseSchema?.tables || [];
       if (newTables.length > 0) {
-        setTablesState(prev => [...prev, ...newTables]);
-        dispatch(appendTables({ db: currentDb, schema: currentSchema, tables: newTables }));
-        setPage(nextPage);
+        dispatch(appendTables({ db, schema, tables: newTables }));
       }
+      dispatch(
+        setTableStatus({
+          db,
+          schema,
+          status: {
+            loading: false,
+            page: nextPage,
+            hasMore: newTables.length >= pageSize,
+            error: undefined,
+          },
+        }),
+      );
     } catch (e) {
       console.error(e);
+      dispatch(setTableStatus({ db, schema, status: { loading: false, error: 'Ошибка загрузки' } }));
     }
   };
+
+  React.useEffect(() => {
+    selectedDatabases.forEach((dbName) => {
+      const hasSchemas =
+        data?.find((db) => db.name === dbName)?.schemas &&
+        (data.find((db) => db.name === dbName)?.schemas?.length ?? 0) > 0;
+      if (hasSchemas) {
+        dispatch(setSchemaStatus({ db: dbName, status: { loaded: true, loading: false } }));
+      }
+    });
+  }, [data, dispatch, selectedDatabases]);
+
+  const selectedSchemaViews = React.useMemo(
+    () =>
+      selectedDatabases.flatMap((db) => {
+        const dbData = data?.find((item) => item.name === db);
+        const schemaNames = selectedSchemasByDb[db] || [];
+        return schemaNames.map((schema) => {
+          const schemaData = dbData?.schemas?.find((s) => s.name === schema);
+          const selection = selectionsByDbSchema[db]?.[schema];
+          return {
+            db,
+            schema,
+            schemaData,
+            selectedTables: selection?.selectedTables || [],
+            selectedColumns: selection?.selectedColumns || [],
+            tableStatus: builder.tableStatusByDbSchema[db]?.[schema],
+          };
+        });
+      }),
+    [builder.tableStatusByDbSchema, data, selectedDatabases, selectedSchemasByDb, selectionsByDbSchema],
+  );
+
+  const isNextDisabled = selectedSources.every((source) => source.selectedColumns.length === 0);
 
   const handleBuildView = () => {
     navigate('/joins');
@@ -135,7 +193,7 @@ const ViewBuilderPage: React.FC = () => {
       onNext={handleBuildView}
       primaryLabel="Перейти к джоинам"
       secondaryLabel="К подключениям"
-      isNextDisabled={selectedSources.every((source) => source.selectedColumns.length === 0)}
+      isNextDisabled={isNextDisabled}
     >
       <VStack align="stretch" spacing={6}>
         <Box>
@@ -155,41 +213,64 @@ const ViewBuilderPage: React.FC = () => {
 
         <Box>
           <DatabaseSelector
-            data={data}
-            selectedDb={currentDb}
-            onChange={(db) => dispatch(setCurrentDb(db))}
+            data={data || []}
+            selectedDbs={selectedDatabases}
+            onChange={handleDatabaseChange}
           />
         </Box>
 
-        {currentDb && selectedDatabase && (
-          <Box>
-            <SchemaSelector
-              selectedDatabase={selectedDatabase}
-              selectedSchema={currentSchema}
-              onChange={(schema) => dispatch(setCurrentSchema(schema))}
-            />
-          </Box>
-        )}
+        <Stack spacing={6}>
+          {selectedDatabases.map((db) => {
+            const dbData = data?.find((item) => item.name === db);
+            const schemas = dbData?.schemas || [];
+            const selectedSchemas = selectedSchemasByDb[db] || [];
+            return (
+              <Box key={db} borderWidth="1px" borderRadius="lg" p={4}>
+                <VStack align="stretch" spacing={4}>
+                  <HStack justify="space-between">
+                    <Heading size="md">{db}</Heading>
+                    <Badge colorScheme="cyan">{selectedSchemas.length} схем</Badge>
+                  </HStack>
+                  <SchemaSelector
+                    database={db}
+                    schemas={schemas}
+                    selectedSchemas={selectedSchemas}
+                    onChange={(schemasValue) => handleSchemaChange(db, schemasValue)}
+                  />
 
-        {currentSchema && schemaDataWithTables && (
-          <TableSelector
-            selectedSchemaData={schemaDataWithTables}
-            selectedTables={selectedTables}
-            onToggleTable={handleToggleTable}
-            onLoadMore={loadMore}
-          />
-        )}
+                  {selectedSchemas.map((schema) => {
+                    const schemaData = schemas.find((s) => s.name === schema);
+                    const selection = selectionsByDbSchema[db]?.[schema];
+                    const tableStatus = builder.tableStatusByDbSchema[db]?.[schema];
+                    return (
+                      <Box key={`${db}-${schema}`} borderWidth="1px" borderRadius="lg" p={3}>
+                        <TableSelector
+                          selectedSchemaData={schemaData}
+                          selectedTables={selection?.selectedTables || []}
+                          onToggleTable={(table) => handleToggleTable(db, schema, table)}
+                          onLoadMore={() => loadMore(db, schema)}
+                          hasMore={tableStatus?.hasMore ?? true}
+                          isLoading={tableStatus?.loading}
+                          dbLabel={db}
+                          schemaLabel={schema}
+                        />
+                      </Box>
+                    );
+                  })}
+                </VStack>
+              </Box>
+            );
+          })}
+        </Stack>
 
         <ColumnsGrid
-          selectedTables={selectedTables}
-          selectedSchemaData={schemaDataWithTables}
-          selectedColumns={selectedColumns}
+          sources={selectedSchemaViews}
           onToggleColumn={handleToggleColumn}
           onSetTableColumns={handleSetTableColumns}
           onAliasChange={handleAliasChange}
         />
 
-        {selectedSources.every((source) => source.selectedColumns.length === 0) && (
+        {isNextDisabled && (
           <Box
             p={4}
             border="1px dashed"

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -43,6 +43,7 @@ const ViewBuilderPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo) as DatabaseInfo[];
+  const savedConnections = useSelector((state: RootState) => state.settings.savedConnections);
   const selectedConnections = useSelector(
     (state: RootState) => state.settings.selectedConnections,
   );
@@ -115,9 +116,15 @@ const ViewBuilderPage: React.FC = () => {
     const nextPage = status.page + 1;
     dispatch(setTableStatus({ db, schema, status: { loading: true } }));
     try {
+      const connectionStrings = selectedConnections
+        .map((key) => ({ key, value: savedConnections[key] }))
+        .filter((item): item is { key: string; value: string } => Boolean(item.value));
+
       const body = {
-        connection_strings: selectedConnections.map((connection_string) => ({
-          connection_string,
+        connection_strings: connectionStrings.map(({ key, value }) => ({
+          connection_string: {
+            [key]: value,
+          },
         })),
         page: nextPage,
         page_size: pageSize,

--- a/client/src/features/viewBuilder/ViewBuilderPage.tsx
+++ b/client/src/features/viewBuilder/ViewBuilderPage.tsx
@@ -24,8 +24,8 @@ const ViewBuilderPage: React.FC = () => {
   const dispatch = useDispatch<AppDispatch>();
   const navigate = useNavigate();
   const data = useSelector((state: RootState) => state.settings.dataBaseInfo);
-  const connectionsMap = useSelector(
-    (state: RootState) => state.settings.connectionsMap,
+  const selectedConnections = useSelector(
+    (state: RootState) => state.settings.selectedConnections,
   );
   const { currentDb, currentSchema, selectedSources } = useSelector(
     (state: RootState) => state.viewBuilder,
@@ -103,7 +103,9 @@ const ViewBuilderPage: React.FC = () => {
     const nextPage = page + 1;
     try {
       const body = {
-        connection_strings: [{ connection_string: connectionsMap }],
+        connection_strings: selectedConnections.map((connection_string) => ({
+          connection_string,
+        })),
         page: nextPage,
         page_size: pageSize,
       };

--- a/client/src/features/viewBuilder/components/ColumnsGrid.tsx
+++ b/client/src/features/viewBuilder/components/ColumnsGrid.tsx
@@ -14,36 +14,39 @@ import {
   Tag,
   SimpleGrid,
 } from '@chakra-ui/react';
+import type { SelectedColumn } from '../viewBuilderSlice';
 
-interface SelectedColumn {
-  table: string;
-  column: string;
-  isUpdateKey?: boolean;
-  alias?: string;
+interface SchemaData {
+  name?: string;
+  tables?: any[];
+}
+
+interface SourceView {
+  db: string;
+  schema: string;
+  selectedTables: string[];
+  selectedColumns: SelectedColumn[];
+  schemaData?: SchemaData;
 }
 
 interface Props {
-  selectedTables: string[];
-  selectedSchemaData: any;
-  selectedColumns: SelectedColumn[];
-  onToggleColumn: (table: string, column: any) => void;
-  onSetTableColumns: (table: string, columns: any[]) => void;
-  onAliasChange: (table: string, column: string, alias: string) => void;
+  sources: SourceView[];
+  onToggleColumn: (db: string, schema: string, table: string, column: any) => void;
+  onSetTableColumns: (db: string, schema: string, table: string, columns: any[]) => void;
+  onAliasChange: (db: string, schema: string, table: string, column: string, alias: string) => void;
 }
 
-const ColumnsList: React.FC<Props> = ({
-  selectedTables,
-  selectedSchemaData,
-  selectedColumns,
+const ColumnsGrid: React.FC<Props> = ({
+  sources,
   onToggleColumn,
   onSetTableColumns,
   onAliasChange,
 }) => {
-  if (selectedTables.length === 0 || !selectedSchemaData) return null;
+  if (sources.every((source) => source.selectedTables.length === 0)) return null;
 
   return (
     <Box w="100%" px={{ base: 0, md: 2 }} py={4}>
-      <VStack align="stretch" spacing={4}>
+      <VStack align="stretch" spacing={6}>
         <HStack justify="space-between" flexWrap="wrap" gap={3}>
           <Box>
             <Text mb={1} fontWeight="bold" fontSize="xl">
@@ -55,99 +58,138 @@ const ColumnsList: React.FC<Props> = ({
           </Box>
         </HStack>
 
-        <SimpleGrid columns={{ base: 1, lg: 2 }} spacing={3}>
-          {selectedTables.map((tableName) => {
-            const tableData = selectedSchemaData.tables?.find((t: any) => t.name === tableName);
-            const allSelected = tableData?.columns?.every((col: any) =>
-              selectedColumns.some((c) => c.table === tableName && c.column === col.name),
-            );
+        {sources.map((source) => {
+          if (source.selectedTables.length === 0 || !source.schemaData) return null;
+          return (
+            <Box key={`${source.db}.${source.schema}`}>
+              <HStack justify="space-between" mb={3}>
+                <VStack align="start" spacing={0}>
+                  <Text fontWeight="semibold">
+                    {source.db}.{source.schema}
+                  </Text>
+                  <Text color="text.muted" fontSize="sm">
+                    {source.selectedTables.length} выбранных таблиц
+                  </Text>
+                </VStack>
+                <Badge colorScheme="purple">{source.schemaData.tables?.length || 0} таблиц</Badge>
+              </HStack>
 
-            return (
-              <Card key={tableName} variant="surface" border="1px solid" borderColor="border.subtle">
-                <CardBody>
-                  <HStack justify="space-between" mb={3} align="center">
-                    <VStack align="start" spacing={0}>
-                      <Text fontWeight="semibold">{tableName}</Text>
-                      <Text color="text.muted" fontSize="sm">
-                        {tableData?.columns?.length || 0} колонок
-                      </Text>
-                    </VStack>
-                    <HStack spacing={2}>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() =>
-                          onSetTableColumns(tableName, allSelected ? [] : tableData?.columns || [])
-                        }
-                      >
-                        {allSelected ? 'Снять все' : 'Выбрать все'}
-                      </Button>
-                    </HStack>
-                  </HStack>
+              <SimpleGrid columns={{ base: 1, lg: 2 }} spacing={3}>
+                {source.selectedTables.map((tableName) => {
+                  const tableData = source.schemaData?.tables?.find((t: any) => t.name === tableName);
+                  const allSelected = tableData?.columns?.every((col: any) =>
+                    source.selectedColumns.some(
+                      (c) => c.table === tableName && c.column === col.name,
+                    ),
+                  );
 
-                  <Stack spacing={2} maxH="360px" overflowY="auto">
-                    {tableData?.columns?.map((col: any) => {
-                      const isChecked = selectedColumns.some(
-                        (c) => c.table === tableName && c.column === col.name,
-                      );
-                      const selected = selectedColumns.find(
-                        (c) => c.table === tableName && c.column === col.name,
-                      );
-                      return (
-                        <Box
-                          key={col.name}
-                          p={3}
-                          border="1px solid"
-                          borderColor={isChecked ? 'accent.primary' : 'border.subtle'}
-                          borderRadius="lg"
-                          bg="bg.elevated"
-                          transition="border-color 0.2s ease, transform 0.2s ease"
-                        >
-                          <HStack justify="space-between" align="start" spacing={3}>
-                            <HStack align="start" spacing={3} flex="1">
-                              <Checkbox
-                                isChecked={isChecked}
-                                onChange={() => onToggleColumn(tableName, col)}
-                                size="lg"
-                              />
-                              <VStack align="start" spacing={1} flex="1">
-                                <HStack spacing={2} wrap="wrap">
-                                  <Text fontWeight="semibold">{col.name}</Text>
-                                  <Tag colorScheme="cyan" variant="subtle">{col.type}</Tag>
-                                  {col.is_primary_key && <Tag colorScheme="green">PK</Tag>}
-                                  {col.is_fk && <Tag colorScheme="purple">FK</Tag>}
-                                  {col.is_unique && <Tag colorScheme="orange">UNQ</Tag>}
-                                </HStack>
-                                <HStack spacing={2} color="text.muted" fontSize="sm">
-                                  <Text>{col.is_nullable ? 'Nullable' : 'Not null'}</Text>
-                                  {col.default && <Badge variant="outline">default</Badge>}
-                                </HStack>
-                                {isChecked && (
-                                  <Input
-                                    placeholder="Алиас колонки (опционально)"
-                                    size="sm"
-                                    variant="filled"
-                                    value={selected?.alias || ''}
-                                    onChange={(e) =>
-                                      onAliasChange(tableName, col.name, e.target.value)
-                                    }
-                                  />
-                                )}
-                              </VStack>
-                            </HStack>
+                  if (!tableData) return null;
+
+                  return (
+                    <Card
+                      key={`${source.db}.${source.schema}.${tableName}`}
+                      variant="surface"
+                      border="1px solid"
+                      borderColor="border.subtle"
+                    >
+                      <CardBody>
+                        <HStack justify="space-between" mb={3} align="center">
+                          <VStack align="start" spacing={0}>
+                            <Text fontWeight="semibold">{tableName}</Text>
+                            <Text color="text.muted" fontSize="sm">
+                              {tableData?.columns?.length || 0} колонок
+                            </Text>
+                          </VStack>
+                          <HStack spacing={2}>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() =>
+                                onSetTableColumns(
+                                  source.db,
+                                  source.schema,
+                                  tableName,
+                                  allSelected ? [] : tableData?.columns || [],
+                                )
+                              }
+                            >
+                              {allSelected ? 'Снять все' : 'Выбрать все'}
+                            </Button>
                           </HStack>
-                        </Box>
-                      );
-                    })}
-                  </Stack>
-                </CardBody>
-              </Card>
-            );
-          })}
-        </SimpleGrid>
+                        </HStack>
+
+                        <Stack spacing={2} maxH="360px" overflowY="auto">
+                          {tableData?.columns?.map((col: any) => {
+                            const isChecked = source.selectedColumns.some(
+                              (c) => c.table === tableName && c.column === col.name,
+                            );
+                            const selected = source.selectedColumns.find(
+                              (c) => c.table === tableName && c.column === col.name,
+                            );
+                            return (
+                              <Box
+                                key={col.name}
+                                p={3}
+                                border="1px solid"
+                                borderColor={isChecked ? 'accent.primary' : 'border.subtle'}
+                                borderRadius="lg"
+                                bg="bg.elevated"
+                                transition="border-color 0.2s ease, transform 0.2s ease"
+                              >
+                                <HStack justify="space-between" align="start" spacing={3}>
+                                  <HStack align="start" spacing={3} flex="1">
+                                    <Checkbox
+                                      isChecked={isChecked}
+                                      onChange={() => onToggleColumn(source.db, source.schema, tableName, col)}
+                                      size="lg"
+                                    />
+                                    <VStack align="start" spacing={1} flex="1">
+                                      <HStack spacing={2} wrap="wrap">
+                                        <Text fontWeight="semibold">{col.name}</Text>
+                                        <Tag colorScheme="cyan" variant="subtle">{col.type}</Tag>
+                                        {col.is_primary_key && <Tag colorScheme="green">PK</Tag>}
+                                        {col.is_fk && <Tag colorScheme="purple">FK</Tag>}
+                                        {col.is_unique && <Tag colorScheme="orange">UNQ</Tag>}
+                                      </HStack>
+                                      <HStack spacing={2} color="text.muted" fontSize="sm">
+                                        <Text>{col.is_nullable ? 'Nullable' : 'Not null'}</Text>
+                                        {col.default && <Badge variant="outline">default</Badge>}
+                                      </HStack>
+                                      {isChecked && (
+                                        <Input
+                                          placeholder="Алиас колонки (опционально)"
+                                          size="sm"
+                                          variant="filled"
+                                          value={selected?.alias || ''}
+                                          onChange={(e) =>
+                                            onAliasChange(
+                                              source.db,
+                                              source.schema,
+                                              tableName,
+                                              col.name,
+                                              e.target.value,
+                                            )
+                                          }
+                                        />
+                                      )}
+                                    </VStack>
+                                  </HStack>
+                                </HStack>
+                              </Box>
+                            );
+                          })}
+                        </Stack>
+                      </CardBody>
+                    </Card>
+                  );
+                })}
+              </SimpleGrid>
+            </Box>
+          );
+        })}
       </VStack>
     </Box>
   );
 };
 
-export default ColumnsList;
+export default ColumnsGrid;

--- a/client/src/features/viewBuilder/components/DatabaseSelector.tsx
+++ b/client/src/features/viewBuilder/components/DatabaseSelector.tsx
@@ -1,24 +1,83 @@
 import React from 'react';
-import { Select } from '@chakra-ui/react';
+import {
+  Badge,
+  Box,
+  Button,
+  Checkbox,
+  HStack,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+  VStack,
+} from '@chakra-ui/react';
+import { ChevronDownIcon } from '@chakra-ui/icons';
 
-interface Props {
-  data: any[];
-  selectedDb: string;
-  onChange: (db: string) => void;
+interface DatabaseInfo {
+  name: string;
 }
 
-const DatabaseSelector: React.FC<Props> = ({ data, selectedDb, onChange }) => (
-  <Select
-    placeholder={data?.length > 0 ? 'Выберите базу данных' : 'Нет доступных баз данных'}
-    value={selectedDb}
-    onChange={(e) => onChange(e.target.value)}
-  >
-    {data?.map((db: any, index: number) => (
-      <option key={index} value={db?.name}>
-        {db?.name}
-      </option>
-    ))}
-  </Select>
-);
+interface Props {
+  data: DatabaseInfo[];
+  selectedDbs: string[];
+  onChange: (dbs: string[]) => void;
+}
+
+const DatabaseSelector: React.FC<Props> = ({ data, selectedDbs, onChange }) => {
+  const toggleDb = (db: string) => {
+    if (selectedDbs.includes(db)) {
+      onChange(selectedDbs.filter((item) => item !== db));
+    } else {
+      onChange([...selectedDbs, db]);
+    }
+  };
+
+  const buttonLabel = selectedDbs.length
+    ? `Выбрано БД: ${selectedDbs.length}`
+    : 'Выберите базы данных';
+
+  return (
+    <Menu closeOnSelect={false}>
+      <MenuButton as={Button} rightIcon={<ChevronDownIcon />} variant="outline">
+        {buttonLabel}
+      </MenuButton>
+      <MenuList maxH="320px" overflowY="auto" minW="280px">
+        {data?.length === 0 && (
+          <MenuItem isDisabled>Нет доступных подключений</MenuItem>
+        )}
+        {data?.map((db) => (
+          <MenuItem key={db.name} closeOnSelect={false}>
+            <HStack justify="space-between" w="100%">
+              <Checkbox
+                isChecked={selectedDbs.includes(db.name)}
+                onChange={() => toggleDb(db.name)}
+              >
+                {db.name}
+              </Checkbox>
+              {selectedDbs.includes(db.name) && <Badge colorScheme="green">выбрано</Badge>}
+            </HStack>
+          </MenuItem>
+        ))}
+        {selectedDbs.length > 0 && (
+          <Box px={3} py={2} borderTop="1px solid" borderColor="border.subtle">
+            <VStack align="start" spacing={1}>
+              <Text fontSize="sm" color="text.muted">
+                Активные подключения
+              </Text>
+              <HStack spacing={2} flexWrap="wrap">
+                {selectedDbs.map((db) => (
+                  <Badge key={db} colorScheme="cyan">
+                    {db}
+                  </Badge>
+                ))}
+              </HStack>
+            </VStack>
+          </Box>
+        )}
+      </MenuList>
+    </Menu>
+  );
+};
 
 export default DatabaseSelector;

--- a/client/src/features/viewBuilder/components/SchemaSelector.tsx
+++ b/client/src/features/viewBuilder/components/SchemaSelector.tsx
@@ -1,27 +1,49 @@
 import React from 'react';
-import { Select } from '@chakra-ui/react';
+import { Badge, Checkbox, HStack, Stack, Text, VStack } from '@chakra-ui/react';
 
-interface Props {
-  selectedDatabase: any;
-  selectedSchema: string;
-  onChange: (schema: string) => void;
+interface SchemaInfo {
+  name: string;
 }
 
-const SchemaSelector: React.FC<Props> = ({ selectedDatabase, selectedSchema, onChange }) => {
-  if (!selectedDatabase) return null;
+interface Props {
+  database: string;
+  schemas: SchemaInfo[];
+  selectedSchemas: string[];
+  onChange: (schemas: string[]) => void;
+}
+
+const SchemaSelector: React.FC<Props> = ({ database, schemas, selectedSchemas, onChange }) => {
+  const toggleSchema = (schema: string) => {
+    if (selectedSchemas.includes(schema)) {
+      onChange(selectedSchemas.filter((item) => item !== schema));
+    } else {
+      onChange([...selectedSchemas, schema]);
+    }
+  };
 
   return (
-    <Select
-      placeholder="Выберите схему"
-      value={selectedSchema}
-      onChange={(e) => onChange(e.target.value)}
-    >
-      {selectedDatabase.schemas?.map((schema: any, index: number) => (
-        <option key={index} value={schema?.name}>
-          {schema?.name}
-        </option>
-      ))}
-    </Select>
+    <VStack align="stretch" spacing={2} border="1px solid" borderColor="border.subtle" p={3} borderRadius="lg">
+      <HStack justify="space-between" mb={1}>
+        <Text fontWeight="semibold">Схемы {database}</Text>
+        <Badge colorScheme="cyan">{selectedSchemas.length} выбрано</Badge>
+      </HStack>
+      <Stack spacing={1} maxH="200px" overflowY="auto">
+        {schemas.map((schema) => (
+          <HStack key={schema.name} justify="space-between">
+            <Checkbox
+              isChecked={selectedSchemas.includes(schema.name)}
+              onChange={() => toggleSchema(schema.name)}
+            >
+              {schema.name}
+            </Checkbox>
+            {selectedSchemas.includes(schema.name) && <Badge colorScheme="green">active</Badge>}
+          </HStack>
+        ))}
+        {schemas.length === 0 && (
+          <Text color="text.muted">Нет доступных схем для этой базы данных.</Text>
+        )}
+      </Stack>
+    </VStack>
   );
 };
 

--- a/client/src/features/viewBuilder/components/TableSelector.tsx
+++ b/client/src/features/viewBuilder/components/TableSelector.tsx
@@ -10,6 +10,8 @@ import {
   Badge,
   Icon,
   Button,
+  Heading,
+  HStack,
 } from '@chakra-ui/react';
 import { FaDatabase } from 'react-icons/fa';
 
@@ -19,10 +21,14 @@ interface Table {
 }
 
 interface Props {
-  selectedSchemaData: { tables: Table[] };
+  selectedSchemaData?: { name?: string; tables?: Table[] };
   selectedTables: string[];
   onToggleTable: (table: string) => void;
   onLoadMore?: () => void;
+  hasMore?: boolean;
+  isLoading?: boolean;
+  dbLabel?: string;
+  schemaLabel?: string;
 }
 
 const TableSelector: React.FC<Props> = ({
@@ -30,25 +36,26 @@ const TableSelector: React.FC<Props> = ({
   selectedTables,
   onToggleTable,
   onLoadMore,
+  hasMore = true,
+  isLoading = false,
+  dbLabel,
+  schemaLabel,
 }) => {
   if (!selectedSchemaData) return null;
 
-  const cardBg = useColorModeValue('gray.100', 'gray.800');        // фон карточки
-  const textColor = useColorModeValue('gray.800', 'yellow.200');  // основной текст
-  const iconColor = useColorModeValue('teal.600', 'teal.300');    // цвет иконки
-  const badgeColorScheme = useColorModeValue('green', 'teal');    // бейдж в обеих темах
+  const cardBg = useColorModeValue('gray.100', 'gray.800');
+  const textColor = useColorModeValue('gray.800', 'yellow.200');
+  const iconColor = useColorModeValue('teal.600', 'teal.300');
+  const badgeColorScheme = useColorModeValue('green', 'teal');
 
   return (
     <Box w="100%" px={4} py={6}>
-      <Text
-        mb={6}
-        fontWeight="bold"
-        textAlign="center"
-        fontSize="xl"
-        color={textColor}
-      >
-        Выберите таблицы:
-      </Text>
+      <HStack mb={4} justify="space-between" flexWrap="wrap" gap={2}>
+        <Heading size="md">
+          {dbLabel ? `${dbLabel}.${schemaLabel}` : 'Выберите таблицы:'}
+        </Heading>
+        <Badge colorScheme="cyan">{selectedTables.length} выбрано</Badge>
+      </HStack>
 
       <SimpleGrid
         columns={{ base: 1, sm: 2, md: 3, lg: 4 }}
@@ -90,9 +97,11 @@ const TableSelector: React.FC<Props> = ({
           </Fade>
         ))}
       </SimpleGrid>
-      {onLoadMore && (
+      {onLoadMore && hasMore && (
         <Box textAlign="center" mt={4}>
-          <Button onClick={onLoadMore}>Загрузить ещё</Button>
+          <Button onClick={onLoadMore} isLoading={isLoading}>
+            Загрузить ещё
+          </Button>
         </Box>
       )}
     </Box>

--- a/client/src/features/viewBuilder/viewBuilderSlice.ts
+++ b/client/src/features/viewBuilder/viewBuilderSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
 
-interface SelectedColumn {
+export interface SelectedColumn {
   db: string;
   schema: string;
   table: string;
@@ -10,33 +10,27 @@ interface SelectedColumn {
   alias?: string;
 }
 
-interface SourceSelection {
-  db: string;
-  schema: string;
+export interface TableSelection {
   selectedTables: string[];
   selectedColumns: SelectedColumn[];
 }
 
+export interface SourceSelection extends TableSelection {
+  db: string;
+  schema: string;
+}
+
 interface JoinSide {
-  source: string;
+  db: string;
   schema: string;
   table: string;
-  main_table: string;
-  column_first: string;
-  column_second: string;
+  column: string;
 }
 
-interface Join {
-  inner: JoinSide;
-}
-
-interface ViewBuilderState {
-  currentDb: string;
-  currentSchema: string;
-  selectedSources: SourceSelection[];
-  joins: Join[];
-  viewName: string;
-  transformations: Record<string, Transform>;
+export interface JoinRule {
+  type: 'INNER';
+  left: JoinSide;
+  right: JoinSide;
 }
 
 export interface MappingJSON {
@@ -59,14 +53,49 @@ export interface Transform {
   mapping: Mapping;
 }
 
+interface LoadState {
+  loading: boolean;
+  loaded?: boolean;
+  error?: string;
+}
+
+interface TableLoadState extends LoadState {
+  page: number;
+  hasMore: boolean;
+}
+
+export interface ViewBuilderState {
+  selectedDatabases: string[];
+  selectedSchemasByDb: Record<string, string[]>;
+  selectionsByDbSchema: Record<string, Record<string, TableSelection>>;
+  schemaStatusByDb: Record<string, LoadState>;
+  tableStatusByDbSchema: Record<string, Record<string, TableLoadState>>;
+  joins: JoinRule[];
+  viewName: string;
+  transformations: Record<string, Transform>;
+}
+
 const initialState: ViewBuilderState = {
-  currentDb: '',
-  currentSchema: '',
-  selectedSources: [],
+  selectedDatabases: [],
+  selectedSchemasByDb: {},
+  selectionsByDbSchema: {},
+  schemaStatusByDb: {},
+  tableStatusByDbSchema: {},
   joins: [],
   viewName: 'MyView',
   transformations: {},
 };
+
+export function flattenSelections(state: ViewBuilderState): SourceSelection[] {
+  return Object.entries(state.selectionsByDbSchema).flatMap(([db, schemas]) =>
+    Object.entries(schemas).map(([schema, selection]) => ({
+      db,
+      schema,
+      selectedTables: selection.selectedTables,
+      selectedColumns: selection.selectedColumns,
+    })),
+  );
+}
 
 const columnKey = (payload: {
   db: string;
@@ -75,53 +104,111 @@ const columnKey = (payload: {
   column: string;
 }) => `${payload.db}.${payload.schema}.${payload.table}.${payload.column}`;
 
-const findOrCreateSource = (
+const getSelection = (
   state: ViewBuilderState,
   db: string,
   schema: string,
-): SourceSelection => {
-  let source = state.selectedSources.find(
-    (s) => s.db === db && s.schema === schema,
-  );
-  if (!source) {
-    source = { db, schema, selectedTables: [], selectedColumns: [] };
-    state.selectedSources.push(source);
+): TableSelection => {
+  if (!state.selectionsByDbSchema[db]) {
+    state.selectionsByDbSchema[db] = {};
   }
-  return source;
+  if (!state.selectionsByDbSchema[db][schema]) {
+    state.selectionsByDbSchema[db][schema] = { selectedTables: [], selectedColumns: [] };
+  }
+  return state.selectionsByDbSchema[db][schema];
 };
 
-const cleanupEmptySources = (state: ViewBuilderState) => {
-  state.selectedSources = state.selectedSources.filter(
-    (source) => source.selectedTables.length > 0 || source.selectedColumns.length > 0,
+const pruneTransformations = (state: ViewBuilderState) => {
+  const validKeys = new Set(
+    flattenSelections(state).flatMap((selection) =>
+      selection.selectedColumns.map((column) => columnKey(column)),
+    ),
   );
+  Object.keys(state.transformations).forEach((key) => {
+    if (!validKeys.has(key)) {
+      delete state.transformations[key];
+    }
+  });
 };
 
 const viewBuilderSlice = createSlice({
   name: 'viewBuilder',
   initialState,
   reducers: {
-    setCurrentDb(state, action: PayloadAction<string>) {
-      state.currentDb = action.payload;
-      state.currentSchema = '';
+    setSelectedDatabases(state, action: PayloadAction<string[]>) {
+      const nextDbs = new Set(action.payload);
+      state.selectedDatabases = action.payload;
+
+      Object.keys(state.selectedSchemasByDb).forEach((db) => {
+        if (!nextDbs.has(db)) {
+          delete state.selectedSchemasByDb[db];
+        }
+      });
+
+      Object.keys(state.selectionsByDbSchema).forEach((db) => {
+        if (!nextDbs.has(db)) {
+          delete state.selectionsByDbSchema[db];
+        }
+      });
+
+      Object.keys(state.schemaStatusByDb).forEach((db) => {
+        if (!nextDbs.has(db)) {
+          delete state.schemaStatusByDb[db];
+        }
+      });
+
+      Object.keys(state.tableStatusByDbSchema).forEach((db) => {
+        if (!nextDbs.has(db)) {
+          delete state.tableStatusByDbSchema[db];
+        }
+      });
+
+      state.joins = state.joins.filter(
+        (join) => nextDbs.has(join.left.db) && nextDbs.has(join.right.db),
+      );
+      pruneTransformations(state);
     },
-    setCurrentSchema(state, action: PayloadAction<string>) {
-      state.currentSchema = action.payload;
+    setSchemasForDb(state, action: PayloadAction<{ db: string; schemas: string[] }>) {
+      const { db, schemas } = action.payload;
+      const allowed = new Set(schemas);
+      state.selectedSchemasByDb[db] = schemas;
+
+      if (state.selectionsByDbSchema[db]) {
+        Object.keys(state.selectionsByDbSchema[db]).forEach((schema) => {
+          if (!allowed.has(schema)) {
+            delete state.selectionsByDbSchema[db][schema];
+          }
+        });
+      }
+
+      if (state.tableStatusByDbSchema[db]) {
+        Object.keys(state.tableStatusByDbSchema[db]).forEach((schema) => {
+          if (!allowed.has(schema)) {
+            delete state.tableStatusByDbSchema[db][schema];
+          }
+        });
+      }
+
+      state.joins = state.joins.filter(
+        (join) => !(join.left.db === db && !allowed.has(join.left.schema)) &&
+          !(join.right.db === db && !allowed.has(join.right.schema)),
+      );
+
+      pruneTransformations(state);
     },
     toggleTable(
       state,
       action: PayloadAction<{ db: string; schema: string; table: string }>,
     ) {
       const { db, schema, table } = action.payload;
-      const source = findOrCreateSource(state, db, schema);
-      if (source.selectedTables.includes(table)) {
-        source.selectedTables = source.selectedTables.filter((t) => t !== table);
-        source.selectedColumns = source.selectedColumns.filter(
-          (c) => !(c.table === table && c.db === db && c.schema === schema),
-        );
+      const selection = getSelection(state, db, schema);
+      if (selection.selectedTables.includes(table)) {
+        selection.selectedTables = selection.selectedTables.filter((t) => t !== table);
+        selection.selectedColumns = selection.selectedColumns.filter((c) => c.table !== table);
       } else {
-        source.selectedTables.push(table);
+        selection.selectedTables.push(table);
       }
-      cleanupEmptySources(state);
+      pruneTransformations(state);
     },
     toggleColumn(
       state,
@@ -129,18 +216,17 @@ const viewBuilderSlice = createSlice({
         SelectedColumn & { isPrimaryKey?: boolean; isUpdateKey?: boolean }
       >,
     ) {
-      const { db, schema, table, column, isPrimaryKey, isUpdateKey } =
-        action.payload;
-      const source = findOrCreateSource(state, db, schema);
-      const idx = source.selectedColumns.findIndex(
+      const { db, schema, table, column, isPrimaryKey, isUpdateKey } = action.payload;
+      const selection = getSelection(state, db, schema);
+      const idx = selection.selectedColumns.findIndex(
         (c) => c.table === table && c.column === column,
       );
       const key = columnKey({ db, schema, table, column });
       if (idx !== -1) {
-        source.selectedColumns.splice(idx, 1);
+        selection.selectedColumns.splice(idx, 1);
         delete state.transformations[key];
       } else {
-        source.selectedColumns.push({
+        selection.selectedColumns.push({
           db,
           schema,
           table,
@@ -159,10 +245,10 @@ const viewBuilderSlice = createSlice({
       }>,
     ) {
       const { db, schema, table, columns } = action.payload;
-      const source = findOrCreateSource(state, db, schema);
-      const otherTables = source.selectedColumns.filter((c) => c.table !== table);
+      const selection = getSelection(state, db, schema);
+      const otherTables = selection.selectedColumns.filter((c) => c.table !== table);
       const existingMap = new Map(
-        source.selectedColumns
+        selection.selectedColumns
           .filter((c) => c.table === table)
           .map((c) => [c.column, c]),
       );
@@ -183,10 +269,8 @@ const viewBuilderSlice = createSlice({
         } as SelectedColumn;
       });
 
-      source.selectedColumns = [...otherTables, ...updatedColumns];
-      if (columns.length === 0) {
-        cleanupEmptySources(state);
-      }
+      selection.selectedColumns = [...otherTables, ...updatedColumns];
+      pruneTransformations(state);
     },
     setViewKey(
       state,
@@ -199,8 +283,8 @@ const viewBuilderSlice = createSlice({
       }>,
     ) {
       const { db, schema, table, column, viewKey } = action.payload;
-      const source = findOrCreateSource(state, db, schema);
-      const col = source.selectedColumns.find(
+      const selection = getSelection(state, db, schema);
+      const col = selection.selectedColumns.find(
         (c) => c.table === table && c.column === column,
       );
       if (col) {
@@ -218,8 +302,8 @@ const viewBuilderSlice = createSlice({
       }>,
     ) {
       const { db, schema, table, column, isUpdateKey } = action.payload;
-      const source = findOrCreateSource(state, db, schema);
-      const col = source.selectedColumns.find(
+      const selection = getSelection(state, db, schema);
+      const col = selection.selectedColumns.find(
         (c) => c.table === table && c.column === column,
       );
       if (col) {
@@ -237,15 +321,15 @@ const viewBuilderSlice = createSlice({
       }>,
     ) {
       const { db, schema, table, column, alias } = action.payload;
-      const source = findOrCreateSource(state, db, schema);
-      const col = source.selectedColumns.find(
+      const selection = getSelection(state, db, schema);
+      const col = selection.selectedColumns.find(
         (c) => c.table === table && c.column === column,
       );
       if (col) {
         col.alias = alias || undefined;
       }
     },
-    addJoin(state, action: PayloadAction<Join>) {
+    addJoin(state, action: PayloadAction<JoinRule>) {
       state.joins.push(action.payload);
     },
     removeJoin(state, action: PayloadAction<number>) {
@@ -271,20 +355,40 @@ const viewBuilderSlice = createSlice({
     setViewName(state, action: PayloadAction<string>) {
       state.viewName = action.payload;
     },
-    resetSelections(state) {
-      state.currentDb = '';
-      state.currentSchema = '';
-      state.selectedSources = [];
-      state.joins = [];
-      state.viewName = 'MyView';
-      state.transformations = {};
+    setSchemaStatus(
+      state,
+      action: PayloadAction<{ db: string; status: Partial<LoadState> }>,
+    ) {
+      const { db, status } = action.payload;
+      const prev = state.schemaStatusByDb[db] || { loading: false };
+      state.schemaStatusByDb[db] = { ...prev, ...status };
+    },
+    setTableStatus(
+      state,
+      action: PayloadAction<{ db: string; schema: string; status: Partial<TableLoadState> }>,
+    ) {
+      const { db, schema, status } = action.payload;
+      if (!state.tableStatusByDbSchema[db]) {
+        state.tableStatusByDbSchema[db] = {};
+      }
+      const prev = state.tableStatusByDbSchema[db][schema] || {
+        loading: false,
+        page: 1,
+        hasMore: true,
+      };
+      state.tableStatusByDbSchema[db][schema] = { ...prev, ...status };
+    },
+    resetSelections() {
+      return initialState;
     },
   },
 });
 
+export const getColumnKey = columnKey;
+
 export const {
-  setCurrentDb,
-  setCurrentSchema,
+  setSelectedDatabases,
+  setSchemasForDb,
   toggleTable,
   toggleColumn,
   setTableColumns,
@@ -295,9 +399,9 @@ export const {
   removeJoin,
   setTransformation,
   setViewName,
+  setSchemaStatus,
+  setTableStatus,
   resetSelections,
 } = viewBuilderSlice.actions;
-
-export const getColumnKey = columnKey;
 
 export default viewBuilderSlice.reducer;

--- a/client/src/features/viewBuilder/viewBuilderSlice.ts
+++ b/client/src/features/viewBuilder/viewBuilderSlice.ts
@@ -20,17 +20,17 @@ export interface SourceSelection extends TableSelection {
   schema: string;
 }
 
-interface JoinSide {
-  db: string;
-  schema: string;
+export interface JoinInner {
   table: string;
-  column: string;
+  schema: string;
+  source: string;
+  main_table: string;
+  column_first: string;
+  column_second: string;
 }
 
 export interface JoinRule {
-  type: 'INNER';
-  left: JoinSide;
-  right: JoinSide;
+  inner: JoinInner;
 }
 
 export interface MappingJSON {
@@ -163,9 +163,7 @@ const viewBuilderSlice = createSlice({
         }
       });
 
-      state.joins = state.joins.filter(
-        (join) => nextDbs.has(join.left.db) && nextDbs.has(join.right.db),
-      );
+      state.joins = state.joins.filter((join) => join.inner && nextDbs.has(join.inner.source));
       pruneTransformations(state);
     },
     setSchemasForDb(state, action: PayloadAction<{ db: string; schemas: string[] }>) {
@@ -190,8 +188,7 @@ const viewBuilderSlice = createSlice({
       }
 
       state.joins = state.joins.filter(
-        (join) => !(join.left.db === db && !allowed.has(join.left.schema)) &&
-          !(join.right.db === db && !allowed.has(join.right.schema)),
+        (join) => !(join.inner?.source === db && !allowed.has(join.inner.schema)),
       );
 
       pruneTransformations(state);

--- a/client/src/layout/Sidebar.tsx
+++ b/client/src/layout/Sidebar.tsx
@@ -70,8 +70,13 @@ const SidebarContent: React.FC = () => {
   const settings = useSelector((state: RootState) => state.settings);
   const builder = useSelector((state: RootState) => state.viewBuilder);
 
+  const selectedColumnsCount = builder.selectedSources.reduce(
+    (acc, source) => acc + source.selectedColumns.length,
+    0,
+  );
+
   const canBuilder = !!settings.dataBaseInfo;
-  const canJoins = builder.selectedColumns.length > 0;
+  const canJoins = selectedColumnsCount > 0;
   const canTransforms = canJoins;
   const canSummary = canTransforms;
 

--- a/client/src/layout/Sidebar.tsx
+++ b/client/src/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Box,
   VStack,
@@ -26,6 +26,7 @@ import {
 } from 'react-icons/fi';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../app/store';
+import { flattenSelections } from '../features/viewBuilder/viewBuilderSlice';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -70,9 +71,13 @@ const SidebarContent: React.FC = () => {
   const settings = useSelector((state: RootState) => state.settings);
   const builder = useSelector((state: RootState) => state.viewBuilder);
 
-  const selectedColumnsCount = builder.selectedSources.reduce(
-    (acc, source) => acc + source.selectedColumns.length,
-    0,
+  const selectedColumnsCount = useMemo(
+    () =>
+      flattenSelections(builder).reduce(
+        (acc, source) => acc + source.selectedColumns.length,
+        0,
+      ),
+    [builder],
   );
 
   const canBuilder = !!settings.dataBaseInfo;

--- a/client/src/layout/Topbar.tsx
+++ b/client/src/layout/Topbar.tsx
@@ -22,7 +22,7 @@ interface TopbarProps {
 }
 
 const Topbar: React.FC<TopbarProps> = ({ onOpenMenu }) => {
-  const { selectedDb, selectedSchema, viewName } = useSelector(
+  const { currentDb, currentSchema, selectedSources, viewName } = useSelector(
     (state: RootState) => state.viewBuilder,
   );
   const background = useColorModeValue('white', 'bg.surface');
@@ -52,9 +52,21 @@ const Topbar: React.FC<TopbarProps> = ({ onOpenMenu }) => {
             <Text fontWeight="bold" fontSize="lg">
               {viewName || 'Data cockpit'}
             </Text>
-            <HStack spacing={2} color="text.muted" fontSize="sm">
-              {selectedDb && <Badge colorScheme="cyan">{selectedDb}</Badge>}
-              {selectedSchema && <Badge colorScheme="purple">{selectedSchema}</Badge>}
+            <HStack spacing={2} color="text.muted" fontSize="sm" flexWrap="wrap">
+              {(selectedSources.length
+                ? selectedSources.map((source) => (
+                    <Badge key={`${source.db}.${source.schema}`} colorScheme="cyan">
+                      {source.db}.{source.schema}
+                    </Badge>
+                  ))
+                : [
+                    currentDb && (
+                      <Badge key={currentDb} colorScheme="cyan">
+                        {currentDb}{currentSchema ? `.${currentSchema}` : ''}
+                      </Badge>
+                    ),
+                  ]
+              ).filter(Boolean)}
             </HStack>
           </Box>
         </HStack>

--- a/client/src/layout/Topbar.tsx
+++ b/client/src/layout/Topbar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Box,
   Flex,
@@ -16,15 +16,16 @@ import { FiMenu, FiSearch, FiWifi } from 'react-icons/fi';
 import { useSelector } from 'react-redux';
 import type { RootState } from '../app/store';
 import ThemeToggle from '../components/ThemeToggle';
+import { flattenSelections } from '../features/viewBuilder/viewBuilderSlice';
 
 interface TopbarProps {
   onOpenMenu: () => void;
 }
 
 const Topbar: React.FC<TopbarProps> = ({ onOpenMenu }) => {
-  const { currentDb, currentSchema, selectedSources, viewName } = useSelector(
-    (state: RootState) => state.viewBuilder,
-  );
+  const builder = useSelector((state: RootState) => state.viewBuilder);
+  const selectedSources = useMemo(() => flattenSelections(builder), [builder]);
+  const { viewName } = builder;
   const background = useColorModeValue('white', 'bg.surface');
 
   return (
@@ -53,20 +54,14 @@ const Topbar: React.FC<TopbarProps> = ({ onOpenMenu }) => {
               {viewName || 'Data cockpit'}
             </Text>
             <HStack spacing={2} color="text.muted" fontSize="sm" flexWrap="wrap">
-              {(selectedSources.length
-                ? selectedSources.map((source) => (
-                    <Badge key={`${source.db}.${source.schema}`} colorScheme="cyan">
-                      {source.db}.{source.schema}
-                    </Badge>
-                  ))
-                : [
-                    currentDb && (
-                      <Badge key={currentDb} colorScheme="cyan">
-                        {currentDb}{currentSchema ? `.${currentSchema}` : ''}
-                      </Badge>
-                    ),
-                  ]
-              ).filter(Boolean)}
+              {selectedSources.length === 0 && (
+                <Badge colorScheme="gray">Источники не выбраны</Badge>
+              )}
+              {selectedSources.map((source) => (
+                <Badge key={`${source.db}.${source.schema}`} colorScheme="cyan">
+                  {source.db}.{source.schema}
+                </Badge>
+              ))}
             </HStack>
           </Box>
         </HStack>


### PR DESCRIPTION
## Summary
- add support for selecting multiple database/schema sources when building views
- update join, transform, and summary steps to handle multi-source selections and display their context
- surface chosen sources in the top bar for better visibility

## Testing
- npm run lint *(fails: existing lint rule violations across the codebase)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e3f6bdc008332af0f7cfd70841eeb)